### PR TITLE
Add simple inventory system

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,20 @@ The `project.godot` file is configured to run `scenes/Main.tscn` by default and 
 2. Press **Play** to run. The player can move and attack.
 3. Use the provided scripts as a starting point for building a larger ARPG.
 
+## Item & Inventory System
+This project now includes a very small inventory framework built entirely with
+scripts. `player.gd` instantiates an `Inventory` node at runtime, so the player
+already has a container for items.
+
+### Using Items
+1. Create a new resource using **Item** (`scripts/item.gd`) for each item type.
+2. To make something collectible, add an `Area3D` node to your scene and attach
+   `scripts/item_pickup.gd`. Assign the `item` property to the Item resource and
+   set an optional amount.
+3. When the player enters the pickup area, the item is added to the player's
+   inventory automatically.
+
+You can inspect or modify the contents of the player's inventory through the
+`inventory` property on `player.gd` or by attaching the `Inventory` script to
+other nodes if needed.
+

--- a/scripts/inventory.gd
+++ b/scripts/inventory.gd
@@ -1,0 +1,28 @@
+extends Node
+class_name Inventory
+
+signal item_added(item: Item)
+signal item_removed(item: Item)
+
+var _items: Dictionary = {}
+
+func add_item(item: Item, amount: int = 1) -> void:
+    var count: int = _items.get(item, 0) + amount
+    _items[item] = min(count, item.max_stack)
+    emit_signal("item_added", item)
+
+func remove_item(item: Item, amount: int = 1) -> void:
+    if not _items.has(item):
+        return
+    var count: int = _items[item] - amount
+    if count <= 0:
+        _items.erase(item)
+    else:
+        _items[item] = count
+    emit_signal("item_removed", item)
+
+func get_quantity(item: Item) -> int:
+    return _items.get(item, 0)
+
+func has_item(item: Item, amount: int = 1) -> bool:
+    return get_quantity(item) >= amount

--- a/scripts/item.gd
+++ b/scripts/item.gd
@@ -1,0 +1,7 @@
+extends Resource
+class_name Item
+
+@export var item_name: String = ""
+@export var description: String = ""
+@export var icon: Texture2D
+@export var max_stack: int = 1

--- a/scripts/item_pickup.gd
+++ b/scripts/item_pickup.gd
@@ -1,0 +1,13 @@
+extends Area3D
+class_name ItemPickup
+
+@export var item: Item
+@export var amount: int = 1
+
+func _ready() -> void:
+    connect("body_entered", _on_body_entered)
+
+func _on_body_entered(body: Node) -> void:
+    if body.has_method("add_item") and item:
+        body.add_item(item, amount)
+        queue_free()

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -7,6 +7,10 @@ extends CharacterBody3D
 @export var attack_angle: float = 45.0 # degrees
 
 var _attack_timer: float = 0.0
+var inventory := Inventory.new()
+
+func _ready() -> void:
+	add_child(inventory)
 
 func _physics_process(delta: float) -> void:
 	_process_movement(delta)
@@ -67,5 +71,9 @@ func perform_attack() -> void:
 	timer.connect("timeout", Callable(attack_area, "queue_free"))
 	attack_area.add_child(timer)
 
-	var bodies = attack_area.get_overlapping_bodies()
-	# TODO: handle damage to overlapping enemies
+        var bodies = attack_area.get_overlapping_bodies()
+        # TODO: handle damage to overlapping enemies
+
+func add_item(item: Item, amount: int = 1) -> void:
+	inventory.add_item(item, amount)
+


### PR DESCRIPTION
## Summary
- add `Item`, `Inventory`, and `ItemPickup` scripts
- extend `player.gd` with an inventory node and `add_item` helper
- document how to use the item and inventory system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d1c6dc594832d8df1cc8b705fd4d1