### PR TITLE
Add basic enemy system

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ The `project.godot` file is configured to run `scenes/Main.tscn` by default and 
 2. Press **Play** to run. The player can move and attack.
 3. Use the provided scripts as a starting point for building a larger ARPG.
 
+## Creating Enemy Scenes
+This repository includes an `enemy.gd` script that handles health and death logic.
+Follow these steps in the Godot editor to create your own enemy scene:
+
+1. **Create a new scene** with a `CharacterBody3D` as the root node.
+2. **Attach** `scripts/enemy.gd` to the root node.
+3. Add a `CollisionShape3D` and `MeshInstance3D` as children for collision and visuals.
+4. Optionally add the node to an **"enemies"** group for organization.
+5. Save the scene, e.g. `scenes/Enemy.tscn`, and instance it into `Main.tscn`.
+
+When the player attacks, any node with a `take_damage` method will lose health
+and be removed when it reaches zero.
+

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -1,0 +1,18 @@
+extends CharacterBody3D
+
+@export var max_health: int = 3
+var current_health: int
+
+signal died
+
+func _ready() -> void:
+    current_health = max_health
+
+func take_damage(amount: int) -> void:
+    current_health -= amount
+    if current_health <= 0:
+        die()
+
+func die() -> void:
+    emit_signal("died")
+    queue_free()

--- a/scripts/enemy.gd.uid
+++ b/scripts/enemy.gd.uid
@@ -1,0 +1,1 @@
+uid://ksacv1pfv9el

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -67,5 +67,7 @@ func perform_attack() -> void:
 	timer.connect("timeout", Callable(attack_area, "queue_free"))
 	attack_area.add_child(timer)
 
-	var bodies = attack_area.get_overlapping_bodies()
-	# TODO: handle damage to overlapping enemies
+        var bodies = attack_area.get_overlapping_bodies()
+        for body in bodies:
+                if body.has_method("take_damage"):
+                        body.take_damage(1)


### PR DESCRIPTION
## Summary
- add `enemy.gd` with health and death logic
- allow player attacks to damage nodes that implement `take_damage`
- document how to create enemy scenes in README

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1c8f74d4832da9c8dde446efc988