### PR TITLE
Add clickable item drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ already has a container for items.
 
 ### Using Items
 1. Create a new resource using **Item** (`scripts/item.gd`) for each item type.
-2. To make something collectible, add an `Area3D` node to your scene and attach
-   `scripts/item_pickup.gd`. Assign the `item` property to the Item resource and
-   set an optional amount.
-3. When the player enters the pickup area, the item is added to the player's
-   inventory automatically.
+2. To make something collectible, add an `Area3D` (or a child of a 3D node) and
+   attach `scripts/item_pickup.gd`. Assign the `item` property and set an
+   optional amount. The script will spawn a floating name label automatically.
+3. When the player approaches the drop, hover the mouse over the label to view
+   the description. Click the item with the **left mouse button** to add it to
+   the player's inventory.
 
 You can inspect or modify the contents of the player's inventory through the
 `inventory` property on `player.gd` or by attaching the `Inventory` script to

--- a/scripts/item_pickup.gd
+++ b/scripts/item_pickup.gd
@@ -4,10 +4,45 @@ class_name ItemPickup
 @export var item: Item
 @export var amount: int = 1
 
+var _player: Node
+var _name_label: Label3D
+var _tooltip: Label3D
+
 func _ready() -> void:
 	connect("body_entered", _on_body_entered)
+	connect("body_exited", _on_body_exited)
+	connect("mouse_entered", _on_mouse_entered)
+	connect("mouse_exited", _on_mouse_exited)
+	connect("input_event", _on_input_event)
+
+	_name_label = Label3D.new()
+	_name_label.text = item.item_name
+	_name_label.billboard = true
+	add_child(_name_label)
+
+	_tooltip = Label3D.new()
+	_tooltip.text = "%s\n%s" % [item.item_name, item.description]
+	_tooltip.billboard = true
+	_tooltip.visible = false
+	_tooltip.position.y += 0.5
+	add_child(_tooltip)
 
 func _on_body_entered(body: Node) -> void:
-	if body.has_method("add_item") and item:
-		body.add_item(item, amount)
-		queue_free()
+	if body.has_method("add_item"):
+		_player = body
+
+func _on_body_exited(body: Node) -> void:
+	if body == _player:
+		_player = null
+
+func _on_mouse_entered() -> void:
+	_tooltip.visible = true
+
+func _on_mouse_exited() -> void:
+	_tooltip.visible = false
+
+func _on_input_event(camera: Node, event: InputEvent, position: Vector3, normal: Vector3, shape_idx: int) -> void:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		if _player and item:
+			_player.add_item(item, amount)
+			queue_free()


### PR DESCRIPTION
## Summary
- make item drops clickable with floating labels and tooltips
- update README to describe the new pickup interaction

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_688d4e668a10832daf2aba058f44307a