### PR TITLE
Implement 2D item tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ already has a container for items.
 1. Create a new resource using **Item** (`scripts/item.gd`) for each item type.
 2. To make something collectible, add an `Area3D` (or a child of a 3D node) and
    attach `scripts/item_pickup.gd`. Assign the `item` property and set an
-   optional amount. The script will spawn a floating name label automatically.
-3. When the player approaches the drop, hover the mouse over the label to view
-   the description. Click the item with the **left mouse button** to add it to
-   the player's inventory.
+   optional amount. The script spawns a 2D tag in a canvas layer so the label is
+   always the same size on screen.
+3. Hover over the tag to view the tooltip and click the label with the **left
+   mouse button** to add the item to the player's inventory.
+4. A `CanvasLayer` named `ItemTagLayer` will be created automatically at
+   runtime. If you prefer to manage it manually, add a `CanvasLayer` with that
+   name to your main scene and optionally customize its draw order.
 
 You can inspect or modify the contents of the player's inventory through the
 `inventory` property on `player.gd` or by attaching the `Inventory` script to

--- a/scripts/item_pickup.gd
+++ b/scripts/item_pickup.gd
@@ -5,27 +5,27 @@ class_name ItemPickup
 @export var amount: int = 1
 
 var _player: Node
-var _name_label: Label3D
-var _tooltip: Label3D
+var _tag: ItemTag
 
 func _ready() -> void:
-	connect("body_entered", _on_body_entered)
-	connect("body_exited", _on_body_exited)
-	connect("mouse_entered", _on_mouse_entered)
-	connect("mouse_exited", _on_mouse_exited)
-	connect("input_event", _on_input_event)
+        connect("body_entered", _on_body_entered)
+        connect("body_exited", _on_body_exited)
+        connect("mouse_entered", _on_mouse_entered)
+        connect("mouse_exited", _on_mouse_exited)
+        connect("input_event", _on_input_event)
 
-	_name_label = Label3D.new()
-	_name_label.text = item.item_name
-	_name_label.billboard = true
-	add_child(_name_label)
+        var layer := get_tree().root.get_node_or_null("ItemTagLayer")
+        if layer == null:
+                layer = CanvasLayer.new()
+                layer.name = "ItemTagLayer"
+                get_tree().root.add_child(layer)
 
-	_tooltip = Label3D.new()
-	_tooltip.text = "%s\n%s" % [item.item_name, item.description]
-	_tooltip.billboard = true
-	_tooltip.visible = false
-	_tooltip.position.y += 0.5
-	add_child(_tooltip)
+        _tag = ItemTag.new()
+        _tag.text = item.item_name
+        _tag.tooltip_text = "%s\n%s" % [item.item_name, item.description]
+        _tag.target = self
+        layer.add_child(_tag)
+        _tag.connect("pressed", Callable(self, "_collect"))
 
 func _on_body_entered(body: Node) -> void:
 	if body.has_method("add_item"):
@@ -36,13 +36,18 @@ func _on_body_exited(body: Node) -> void:
 		_player = null
 
 func _on_mouse_entered() -> void:
-	_tooltip.visible = true
+        pass
 
 func _on_mouse_exited() -> void:
-	_tooltip.visible = false
+        pass
 
 func _on_input_event(camera: Node, event: InputEvent, position: Vector3, normal: Vector3, shape_idx: int) -> void:
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		if _player and item:
-			_player.add_item(item, amount)
-			queue_free()
+        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                _collect()
+
+func _collect() -> void:
+        if _player and item:
+                _player.add_item(item, amount)
+        if _tag:
+                _tag.queue_free()
+        queue_free()

--- a/scripts/item_tag.gd
+++ b/scripts/item_tag.gd
@@ -1,0 +1,27 @@
+extends Button
+class_name ItemTag
+
+var target: Node3D
+@export var vertical_offset: float = 1.5
+var _camera: Camera3D
+
+func _ready() -> void:
+    _camera = get_viewport().get_camera_3d()
+    focus_mode = FOCUS_NONE
+    size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+    size_flags_vertical = Control.SIZE_SHRINK_CENTER
+    clip_text = false
+
+func _process(delta: float) -> void:
+    if not target or not is_instance_valid(target):
+        queue_free()
+        return
+    if not _camera:
+        _camera = get_viewport().get_camera_3d()
+        if not _camera:
+            return
+    var pos := target.global_transform.origin
+    pos.y += vertical_offset
+    var screen_point: Vector2 = _camera.unproject_position(pos)
+    position = screen_point - size * 0.5
+    visible = _camera.is_position_behind(pos) == false


### PR DESCRIPTION
## Summary
- show item tags through new `ItemTag` overlay
- convert `ItemPickup` to spawn 2D labels that keep constant screen size
- document `ItemTagLayer` setup and usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d5156ea6c832da76c8e93e5b3d285