### PR TITLE
Implement tiered affix system with chaos crafting and tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,36 @@ to games like Diablo II or Path of Exile.
 4. Picking up a world item while the inventory is open will put that item on the
    cursor instead of adding it directly to the inventory.
 
+## Affix System
+Items may roll up to six affixes. Affixes are defined as separate resources so
+new ones can be added without modifying code.
+
+### Creating an AffixDefinition
+1. Create a new resource using **AffixDefinition** (`scripts/affix_definition.gd`).
+2. Fill out the exported properties:
+   - **name** – display name of the affix.
+   - **description** – template string shown to players. Use `{value}` where the
+     rolled number should appear.
+   - **stat_key** or **main_stat** – which stat the affix modifies.
+   - **tiers** – an array of `Vector2(min, max)` values for each tier.
+   - **flags** – optional keywords that enable unique behaviour. For example,
+     the `body_to_mind` flag converts all Body bonuses to Mind.
+3. Save the resource inside `resources/affixes/` and assign it to an item's
+   `affix_pool` array. Call `reroll_affixes()` to roll new affixes.
+
+Three sample definitions are included:
+- `move_speed.tres` – numeric tiers for movement speed.
+- `life_steal.tres` – unique effect that grants 1% life steal.
+- `body_to_mind.tres` – unique flag causing Body increases to apply to Mind.
+
+### Crafting with Chaos Orbs
+When a **Chaos Orb** is on the cursor, right‑clicking an item consumes one orb
+and rerolls all of that item's affixes.
+
+### Displaying Affixes
+Hovering over an item tag in the world or over an inventory slot now shows the
+item's affixes in its tooltip.
+
 ## Enemy Behavior
 Enemies now wander around randomly until the player gets close. When the player
 enters the `detection_range` exported on `enemy.gd`, the enemy will chase the

--- a/resources/affixes/body_to_mind.tres
+++ b/resources/affixes/body_to_mind.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="AffixDefinition" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/affix_definition.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+name = "Mind Conversion"
+description = "Increases to Body instead apply to Mind"
+flags = ["body_to_mind"]
+tiers = [Vector2(0,0)]

--- a/resources/affixes/life_steal.tres
+++ b/resources/affixes/life_steal.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="AffixDefinition" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/affix_definition.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+name = "Life Steal"
+description = "Steal {value}% of life on hit"
+stat_key = "life_steal"
+tiers = [Vector2(1,1)]

--- a/resources/affixes/move_speed.tres
+++ b/resources/affixes/move_speed.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="AffixDefinition" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/affix_definition.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+name = "Move Speed"
+description = "{value}% increased move speed"
+stat_key = "move_speed"
+tiers = [Vector2(5,10), Vector2(10,20), Vector2(20,30)]

--- a/scripts/affix.gd
+++ b/scripts/affix.gd
@@ -1,13 +1,17 @@
-extends Resource
 class_name Affix
+extends Resource
 
-# Describes a single modifier that can be attached to an item.  Affixes are
-# applied to the player's Stats when the containing item is equipped.
-#
-# `stat_modifiers` uses keys from `Stats.MainStat` to modify the core stats
-# BODY, MIND, SOUL and FORTUNE.
+# Runtime affix attached to an item. Affix instances are generated from
+# `AffixDefinition` resources and store the rolled tier and numeric value. The
+# dictionaries hold the actual stat bonuses applied by `Stats`.
 
-@export var stat_modifiers: Dictionary = {}
-@export var damage_bonus: float = 0.0
-@export var move_speed_bonus: float = 0.0
-@export var defense_bonus: float = 0.0
+@export var name: String = ""
+@export var tier: int = 1
+@export var description: String = ""
+@export var main_stat_bonuses: Dictionary = {}  # key: Stats.MainStat, value: float
+@export var stat_bonuses: Dictionary = {}  # key: String, value: float
+@export var flags: Array[String] = []
+
+
+func get_description() -> String:
+	return "T%s %s" % [tier, description]

--- a/scripts/affix_definition.gd
+++ b/scripts/affix_definition.gd
@@ -1,0 +1,63 @@
+class_name AffixDefinition
+extends Resource
+
+# Data-driven definition of an affix type. AffixDefinitions describe the
+# possible tiers, value ranges and stat affected by an affix.
+#
+# `tiers` is an Array of Vector2 where `x` is the minimum roll and `y` is the
+# maximum roll for that tier. Tier indexing starts at 1.
+#
+# `stat_key` determines which stat in `Stats` this affix modifies. Examples:
+#   "damage"       -> affects Stats.get_damage()
+#   "move_speed"   -> affects Stats.get_move_speed()
+#   "defense"      -> affects Stats.get_defense()
+#   "life_steal"   -> retrievable through Stats.get_misc("life_steal")
+#
+# `main_stat` can be used to modify the primary stats defined in
+# Stats.MainStat.  Leave `main_stat` as -1 when the affix modifies one of the
+# string based `stat_key` values.
+#
+# `flags` may contain special keywords that toggle unique behaviour when the
+# affix is applied. For example, a flag of "body_to_mind" will cause all BODY
+# bonuses to be applied to MIND instead.
+#
+# `description` is a template string used to show the rolled value. The token
+# `{value}` will be replaced with the numeric roll when generating a tooltip.
+
+@export var name: String = ""
+@export var description: String = ""
+@export var stat_key: String = ""
+@export var main_stat: int = -1
+@export var tiers: Array[Vector2] = []
+@export var flags: Array[String] = []
+
+
+func get_tier_count() -> int:
+	return tiers.size()
+
+
+func roll(tier: int) -> Affix:
+	# Rolls a new Affix instance for the given tier.
+	tier = clamp(tier, 1, tiers.size())
+	var range: Vector2 = tiers[tier - 1]
+	var value := randf_range(range.x, range.y)
+	var affix := Affix.new()
+	affix.name = name
+	affix.tier = tier
+	var text := description
+	if text.find("{value}") != -1:
+		text = description.format({"value": _format_value(value)})
+	affix.description = text
+	if main_stat != -1:
+		affix.main_stat_bonuses[main_stat] = value
+	elif stat_key != "":
+		affix.stat_bonuses[stat_key] = value
+	affix.flags = flags.duplicate()
+	return affix
+
+
+func _format_value(v: float) -> String:
+	# Helper to trim trailing zeros for nicer tooltip text.
+	if abs(v - int(v)) < 0.01:
+		return str(int(v))
+	return str(round(v, 2))

--- a/scripts/inventory_slot.gd
+++ b/scripts/inventory_slot.gd
@@ -1,5 +1,5 @@
-extends Control
 class_name InventorySlot
+extends Control
 
 signal pressed(index: int)
 signal right_clicked(index: int)
@@ -17,8 +17,10 @@ var amount: int = 0
 @onready var icon := $Icon if has_node("Icon") else null
 @onready var quantity_label := $Amount if has_node("Amount") else null
 
+
 func _ready() -> void:
 	update_display()
+
 
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed:
@@ -27,18 +29,28 @@ func _gui_input(event: InputEvent) -> void:
 		elif event.button_index == MOUSE_BUTTON_RIGHT:
 			emit_signal("right_clicked", index)
 
+
 func set_item(value: Item) -> void:
 	item = value
 	update_display()
+
 
 func set_amount(value: int) -> void:
 	amount = value
 	update_display()
 
+
 func update_display() -> void:
 	#print("updating display")
 	if icon:
-		#print("updating icon")
 		icon.texture = item.icon if item else null
 	if quantity_label:
 		quantity_label.text = str(amount) if amount >= 1 else ""
+	if item:
+		var tip := "%s\n%s" % [item.item_name, item.description]
+		var aff_text := item.get_affix_text()
+		if aff_text != "":
+			tip += "\n" + aff_text
+		tooltip_text = tip
+	else:
+		tooltip_text = ""

--- a/scripts/inventory_ui.gd
+++ b/scripts/inventory_ui.gd
@@ -1,5 +1,5 @@
-extends CanvasLayer
 class_name InventoryUI
+extends CanvasLayer
 
 @export var slots_parent_path: NodePath
 @export var equip_slots_parent_path: NodePath
@@ -18,6 +18,7 @@ var _cursor_item: Item = null
 var _cursor_amount: int = 0
 var _cursor_icon: TextureRect
 var _cursor_label: Label
+
 
 func _ready() -> void:
 	if slots_parent_path != NodePath():
@@ -38,7 +39,9 @@ func _ready() -> void:
 			if slot.has_signal("pressed"):
 				slot.connect("pressed", Callable(self, "_on_equip_slot_pressed").bind(slot))
 			if slot.has_signal("right_clicked"):
-				slot.connect("right_clicked", Callable(self, "_on_equip_slot_right_clicked").bind(slot))
+				slot.connect(
+					"right_clicked", Callable(self, "_on_equip_slot_right_clicked").bind(slot)
+				)
 	if camera_path != NodePath():
 		_camera = get_node(camera_path)
 		if _camera:
@@ -57,9 +60,11 @@ func _ready() -> void:
 	if _equipment:
 		bind_equipment(_equipment)
 
+
 func _process(_delta: float) -> void:
 	if _cursor_icon.visible:
 		_cursor_icon.global_position = get_viewport().get_mouse_position()
+
 
 func bind_inventory(inv: Inventory) -> void:
 	_inventory = inv
@@ -68,17 +73,20 @@ func bind_inventory(inv: Inventory) -> void:
 		_inventory.connect("slot_changed", Callable(self, "_on_slot_changed"))
 		_update_slots()
 
+
 func bind_equipment(eq: EquipmentManager) -> void:
 	_equipment = eq
 	if _equipment:
 		_equipment.connect("slot_changed", Callable(self, "_on_equip_slot_changed"))
 		_update_equip_slots()
 
+
 func toggle() -> void:
 	if _open:
 		close()
 	else:
 		open()
+
 
 func open() -> void:
 	_open = true
@@ -88,11 +96,13 @@ func open() -> void:
 	_update_equip_slots()
 	_update_cursor_visibility()
 
+
 func close() -> void:
 	_open = false
 	visible = false
 	_shift_camera(false)
 	_update_cursor_visibility()
+
 
 func _shift_camera(open: bool) -> void:
 	if not _camera:
@@ -101,7 +111,10 @@ func _shift_camera(open: bool) -> void:
 	if open:
 		target.x += camera_shift
 	var tween := create_tween()
-	tween.tween_property(_camera, "position", target, 0.25).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+	tween.tween_property(_camera, "position", target, 0.25).set_trans(Tween.TRANS_SINE).set_ease(
+		Tween.EASE_IN_OUT
+	)
+
 
 func _on_slot_changed(index: int, item: Item, amount: int) -> void:
 	if index < 0 or index >= _slots.size():
@@ -112,8 +125,10 @@ func _on_slot_changed(index: int, item: Item, amount: int) -> void:
 	if slot.has_method("set_amount"):
 		slot.set_amount(amount)
 
+
 func _on_equip_slot_changed(_slot: String, _item: Item) -> void:
 	_update_equip_slots()
+
 
 func _on_slot_pressed(index: int) -> void:
 	if not _inventory:
@@ -134,11 +149,28 @@ func _on_slot_pressed(index: int) -> void:
 			_cursor_amount = data["amount"]
 			_update_cursor()
 
+
 func _on_slot_right_clicked(index: int) -> void:
-	if not _inventory or not _equipment:
+	if not _inventory:
 		return
+
+		# Consume one Chaos Orb and reroll the item's affixes.
 	var data = _inventory.get_slot(index)
 	var item: Item = data["item"]
+	if _cursor_item and _cursor_item.item_name == "Chaos Orb" and item:
+		# Consume one Chaos Orb and reroll the item's affixes.
+		item.reroll_affixes()
+		_cursor_amount -= 1
+		if _cursor_amount <= 0:
+			_cursor_item = null
+			_cursor_amount = 0
+		_inventory.clear_slot(index)
+		_inventory.place_item(index, item, data["amount"])
+		_update_cursor()
+		_update_slots()
+		return
+	if not _equipment:
+		return
 	if item and item.equip_slot != "":
 		_inventory.clear_slot(index)
 		var swapped = _equipment.equip(item)
@@ -148,6 +180,7 @@ func _on_slot_right_clicked(index: int) -> void:
 				_inventory.add_item(leftover["item"], leftover["amount"])
 		_update_slots()
 		_update_equip_slots()
+
 
 func _on_equip_slot_pressed(_index: int, slot: InventorySlot) -> void:
 	if not _equipment:
@@ -170,6 +203,7 @@ func _on_equip_slot_pressed(_index: int, slot: InventorySlot) -> void:
 			_update_cursor()
 			_update_equip_slots()
 
+
 func _on_equip_slot_right_clicked(_index: int, slot: InventorySlot) -> void:
 	if not _equipment or not _inventory:
 		return
@@ -178,6 +212,7 @@ func _on_equip_slot_right_clicked(_index: int, slot: InventorySlot) -> void:
 		_inventory.add_item(item)
 		_update_slots()
 		_update_equip_slots()
+
 
 func _update_slots() -> void:
 	if not _inventory:
@@ -191,6 +226,7 @@ func _update_slots() -> void:
 		if slot.has_method("set_amount"):
 			slot.set_amount(data["amount"])
 
+
 func _update_equip_slots() -> void:
 	if not _equipment:
 		return
@@ -201,6 +237,7 @@ func _update_equip_slots() -> void:
 		if slot.has_method("set_amount"):
 			slot.set_amount(1 if item else 0)
 
+
 func pickup_to_cursor(item: Item, amount: int) -> void:
 	if _cursor_item:
 		_inventory.add_item(_cursor_item, _cursor_amount)
@@ -208,11 +245,13 @@ func pickup_to_cursor(item: Item, amount: int) -> void:
 	_cursor_amount = amount
 	_update_cursor()
 
+
 func _update_cursor() -> void:
 	if _cursor_item:
 		_cursor_icon.texture = _cursor_item.icon
 		_cursor_label.text = str(_cursor_amount) if _cursor_amount > 1 else ""
 	_update_cursor_visibility()
+
 
 func _update_cursor_visibility() -> void:
 	_cursor_icon.visible = _cursor_item != null and _open

--- a/scripts/item.gd
+++ b/scripts/item.gd
@@ -1,10 +1,13 @@
-extends Resource
 class_name Item
+extends Resource
+
+# Maximum number of affixes an item may hold.
+const MAX_AFFIXES := 6
 
 # Basic item resource used by the inventory and equipment systems.
 # Items may represent consumables or equippable gear depending on their
 # configuration.  Equippable items expose an `equip_slot` and a list of
-# `Affix` resources that describe any bonuses the item grants when equipped.
+# `Affix` instances that describe bonuses the item grants when equipped.
 
 @export var item_name: String = ""
 @export var description: String = ""
@@ -15,7 +18,30 @@ class_name Item
 # items such as consumables.  Example values: "weapon", "armor", "ring".
 @export var equip_slot: String = ""
 
-# Affixes attached to this item. Each affix modifies player statistics when
-# the item is equipped.  Affixes can be authored in the editor and added to an
-# item to create variations without additional code.
+# Pool of definitions this item may roll affixes from when crafted.
+@export var affix_pool: Array[AffixDefinition] = []
+
+# Affixes currently attached to this item.
 @export var affixes: Array[Affix] = []
+
+
+func reroll_affixes() -> void:
+	# Clears existing affixes and rolls new ones from `affix_pool`.
+	affixes.clear()
+	if affix_pool.is_empty():
+		return
+	var pool := affix_pool.duplicate()
+	var count := randi_range(1, min(MAX_AFFIXES, pool.size()))
+	for i in range(count):
+		var def: AffixDefinition = pool.pick_random()
+		pool.erase(def)
+		var tier := randi_range(1, def.get_tier_count())
+		affixes.append(def.roll(tier))
+
+
+func get_affix_text() -> String:
+	# Returns a multi-line string listing all affixes on the item.
+	var lines: Array[String] = []
+	for a in affixes:
+		lines.append(a.get_description())
+	return "\n".join(lines)

--- a/scripts/item_pickup.gd
+++ b/scripts/item_pickup.gd
@@ -1,11 +1,12 @@
-extends Area3D
 class_name ItemPickup
+extends Area3D
 
 @export var item: Item
 @export var amount: int = 1
 
 var _player: Node
 var _tag: ItemTag
+
 
 func _ready() -> void:
 	connect("body_entered", _on_body_entered)
@@ -16,14 +17,13 @@ func _ready() -> void:
 
 	var layer = get_tree().get_root().get_node_or_null("WorldRoot/ItemTagLayer")
 
-	var label = Label.new()
-	#label.text = "Hello from canvas layer!"
-	#label.position = Vector2(100, 100)
-	#layer.add_child(label)
-
 	_tag = ItemTag.new()
 	_tag.text = item.item_name
-	_tag.tooltip_text = "%s\n%s" % [item.item_name, item.description]
+	var tip := "%s\n%s" % [item.item_name, item.description]
+	var aff_text := item.get_affix_text()
+	if aff_text != "":
+		tip += "\n" + aff_text
+	_tag.tooltip_text = tip
 	_tag.target = self
 	layer.add_child(_tag)
 	_tag.connect("pressed", Callable(self, "_collect"))
@@ -33,23 +33,30 @@ func _on_body_entered(body: Node) -> void:
 	if body.has_method("add_item"):
 		_player = body
 
+
 func _on_body_exited(body: Node) -> void:
 	if body == _player:
 		_player = null
 
+
 func _on_mouse_entered() -> void:
-		pass
+	pass
+
 
 func _on_mouse_exited() -> void:
-		pass
+	pass
 
-func _on_input_event(camera: Node, event: InputEvent, position: Vector3, normal: Vector3, shape_idx: int) -> void:
-		if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-				_collect()
+
+func _on_input_event(
+	_camera: Node, event: InputEvent, _position: Vector3, _normal: Vector3, _shape_idx: int
+) -> void:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		_collect()
+
 
 func _collect() -> void:
-		if _player and item:
-				_player.add_item(item, amount)
-				if _tag:
-						_tag.queue_free()
-				get_parent().queue_free()
+	if _player and item:
+		_player.add_item(item, amount)
+		if _tag:
+			_tag.queue_free()
+		get_parent().queue_free()

--- a/scripts/stats.gd
+++ b/scripts/stats.gd
@@ -1,20 +1,20 @@
-extends Resource
 class_name Stats
+extends Resource
 
-# Holds the core and derived statistics for an actor.  The class exposes helper
-# functions to query values after all affix modifiers have been applied.  This
-# keeps the logic for calculating final damage, movement speed and defenses in a
-# single place.
+# Holds the core and derived statistics for an actor. Affixes are applied to
+# this resource and contribute bonuses to the base values. The system is fully
+# data driven – new stats can be introduced simply by referencing a new
+# `stat_key` in an `AffixDefinition`.
 
 # Enumeration of the four primary stats used throughout the game.
 enum MainStat { BODY, MIND, SOUL, FORTUNE }
 
 # Base values before equipment or other bonuses are applied.
 var base_main := {
-    MainStat.BODY: 0,
-    MainStat.MIND: 0,
-    MainStat.SOUL: 0,
-    MainStat.FORTUNE: 0,
+	MainStat.BODY: 0,
+	MainStat.MIND: 0,
+	MainStat.SOUL: 0,
+	MainStat.FORTUNE: 0,
 }
 
 var base_damage: float = 1.0
@@ -24,38 +24,73 @@ var base_defense: float = 0.0
 # Internal list of affixes currently affecting the stats.
 var _affixes: Array[Affix] = []
 
+# Cached bonuses calculated from the affix list.
+var _main_bonus := {
+	MainStat.BODY: 0.0,
+	MainStat.MIND: 0.0,
+	MainStat.SOUL: 0.0,
+	MainStat.FORTUNE: 0.0,
+}
+var _stat_bonus: Dictionary = {}
+var _flags: Dictionary = {}
+
 # -- Affix management -------------------------------------------------------
 
+
 func apply_affix(affix: Affix) -> void:
-    # Adds an affix to the active list if it is not already present.
-    if affix and not _affixes.has(affix):
-        _affixes.append(affix)
+	# Adds an affix to the active list and recalculates bonuses.
+	if affix and not _affixes.has(affix):
+		_affixes.append(affix)
+		_recalculate_bonuses()
+
 
 func remove_affix(affix: Affix) -> void:
-    _affixes.erase(affix)
+	_affixes.erase(affix)
+	_recalculate_bonuses()
+
+
+func _recalculate_bonuses() -> void:
+	# Rebuilds cached bonus dictionaries based on the current affix list.
+	_main_bonus = {
+		MainStat.BODY: 0.0,
+		MainStat.MIND: 0.0,
+		MainStat.SOUL: 0.0,
+		MainStat.FORTUNE: 0.0,
+	}
+	_stat_bonus.clear()
+	_flags.clear()
+	for aff in _affixes:
+		for f in aff.flags:
+			_flags[f] = true
+	for aff in _affixes:
+		for k in aff.main_stat_bonuses:
+			var target := k
+			if _flags.has("body_to_mind") and k == MainStat.BODY:
+				target = MainStat.MIND
+			_main_bonus[target] = _main_bonus.get(target, 0) + aff.main_stat_bonuses[k]
+		for key in aff.stat_bonuses:
+			_stat_bonus[key] = _stat_bonus.get(key, 0.0) + aff.stat_bonuses[key]
+
 
 # -- Query helpers ----------------------------------------------------------
 
+
 func get_main(stat: MainStat) -> int:
-    var value: int = base_main.get(stat, 0)
-    for affix in _affixes:
-        value += affix.stat_modifiers.get(stat, 0)
-    return value
+	return int(base_main.get(stat, 0) + _main_bonus.get(stat, 0))
+
 
 func get_damage() -> float:
-    var value: float = base_damage
-    for affix in _affixes:
-        value += affix.damage_bonus
-    return value
+	return base_damage + _stat_bonus.get("damage", 0.0)
+
 
 func get_move_speed() -> float:
-    var value: float = base_move_speed
-    for affix in _affixes:
-        value += affix.move_speed_bonus
-    return value
+	return base_move_speed + _stat_bonus.get("move_speed", 0.0)
+
 
 func get_defense() -> float:
-    var value: float = base_defense
-    for affix in _affixes:
-        value += affix.defense_bonus
-    return value
+	return base_defense + _stat_bonus.get("defense", 0.0)
+
+
+func get_misc(stat: String) -> float:
+	# Allows retrieval of unique numeric stats such as "life_steal".
+	return _stat_bonus.get(stat, 0.0)


### PR DESCRIPTION
## Summary
- add data-driven AffixDefinition with tier ranges and unique flags
- allow items to roll and reroll affixes; Chaos Orbs reroll on right-click
- show affixes in tooltips for world drops and inventory slots

## Testing
- `gdformat scripts/affix_definition.gd scripts/affix.gd scripts/stats.gd scripts/item.gd scripts/inventory_ui.gd scripts/inventory_slot.gd scripts/item_pickup.gd`
- `gdlint scripts/affix_definition.gd scripts/affix.gd scripts/stats.gd scripts/item.gd scripts/inventory_ui.gd scripts/inventory_slot.gd scripts/item_pickup.gd`


------
https://chatgpt.com/codex/tasks/task_e_688e5e107b90832d8cfea71b5d48c05f