### PR TITLE
Add Fireball skill and skill assignment UI scaffolding

### DIFF
--- a/resources/skills/fireball.tres
+++ b/resources/skills/fireball.tres
@@ -1,0 +1,16 @@
+[gd_resource type="Resource" script_class="FireballSkill" load_steps=2 format=3 uid="uid://fireballskill"]
+
+[ext_resource type="Script" uid="uid://fireballscript" path="res://scripts/skills/fireball_skill.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+speed = 10.0
+range = 15.0
+explosion_radius = 2.0
+name = "Fireball"
+mana_cost = 5.0
+cooldown = 1.0
+duration = 0.0
+move_multiplier = 1.0
+damage_type = null
+tags = Array[String](["Spell", "Projectile", "AoE"])

--- a/scripts/skill.gd
+++ b/scripts/skill.gd
@@ -4,6 +4,7 @@ extends Resource
 const Stats = preload("res://scripts/stats.gd")
 
 @export var name: String = ""
+@export var icon: Texture2D
 @export var mana_cost: float = 0.0
 @export var cooldown: float = 0.0
 @export var duration: float = 0.0

--- a/scripts/skill_slot.gd
+++ b/scripts/skill_slot.gd
@@ -1,0 +1,20 @@
+class_name SkillSlot
+extends TextureButton
+
+signal pressed(index: int)
+signal right_clicked(index: int)
+
+@export var index: int = -1
+var skill: Skill = null
+
+func _gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		if event.button_index == MOUSE_BUTTON_LEFT:
+			emit_signal("pressed", index)
+		elif event.button_index == MOUSE_BUTTON_RIGHT:
+			emit_signal("right_clicked", index)
+
+func set_skill(value: Skill) -> void:
+	skill = value
+	texture_normal = skill.icon if skill else null
+	tooltip_text = skill.name if skill else ""

--- a/scripts/skills/fireball_skill.gd
+++ b/scripts/skills/fireball_skill.gd
@@ -1,0 +1,66 @@
+extends Skill
+class_name FireballSkill
+
+const Stats = preload("res://scripts/stats.gd")
+
+@export var speed: float = 10.0
+@export var range: float = 15.0
+@export var explosion_radius: float = 2.0
+
+func perform(user):
+	if user == null:
+		return
+	var direction: Vector3
+	if user.has_method("_get_click_direction"):
+		direction = user._get_click_direction()
+	else:
+		direction = -user.global_transform.basis.z
+	user.look_at(user.global_transform.origin + direction, Vector3.UP)
+	var projectile = Area3D.new()
+	var shape = SphereShape3D.new()
+	shape.radius = 0.2
+	var collider = CollisionShape3D.new()
+	collider.shape = shape
+	projectile.add_child(collider)
+	projectile.global_transform.origin = user.global_transform.origin + direction
+	projectile.body_entered.connect(_on_projectile_body_entered.bind(projectile, user))
+	user.get_parent().add_child(projectile)
+	var travel_time = range / speed
+	var tween = projectile.create_tween()
+	tween.tween_property(projectile, "global_transform:origin", user.global_transform.origin + direction * range, travel_time)
+	tween.connect("finished", Callable(self, "_on_projectile_finished").bind(projectile, user))
+
+func _on_projectile_body_entered(body, projectile, user):
+	if body and body.has_method("take_damage"):
+		if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
+			var dmg_map = user.stats.get_all_damage(tags)
+			var solar_base = user.stats.base_damage[Stats.DamageType.SOLAR] + 3
+			dmg_map[Stats.DamageType.SOLAR] = user.stats._compute_stat_tagged(solar_base, "solar_damage", tags)
+			for dt in dmg_map.keys():
+				var dmg = dmg_map[dt]
+				if dmg > 0:
+					body.take_damage(dmg, dt)
+	_explode(projectile.global_transform.origin, user)
+	projectile.queue_free()
+
+func _on_projectile_finished(projectile, user):
+	_explode(projectile.global_transform.origin, user)
+	projectile.queue_free()
+
+func _explode(origin: Vector3, user):
+	var shape = SphereShape3D.new()
+	shape.radius = explosion_radius
+	var params = PhysicsShapeQueryParameters3D.new()
+	params.shape = shape
+	params.transform = Transform3D(Basis(), origin)
+	params.collide_with_bodies = true
+	var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
+	var solar_base = user.stats.base_damage[Stats.DamageType.SOLAR] + 1
+	var dmg = user.stats._compute_stat_tagged(solar_base, "solar_damage", tags)
+	for result in bodies:
+		var body = result.get("collider")
+		if body and body.has_method("take_damage"):
+			if user.is_in_group("player") and body.is_in_group("enemy"):
+				body.take_damage(dmg, Stats.DamageType.SOLAR)
+			if user.is_in_group("enemy") and body.is_in_group("player"):
+				body.take_damage(dmg, Stats.DamageType.SOLAR)

--- a/scripts/skills_ui.gd
+++ b/scripts/skills_ui.gd
@@ -1,0 +1,98 @@
+class_name SkillsUI
+extends CanvasLayer
+
+@export var known_skills_parent_path: NodePath
+@export var slots_parent_path: NodePath
+
+var _player
+var _known_slots: Array = []
+var _slots: Array = []
+var _open := false
+var _cursor_skill: Skill = null
+var _cursor_icon: TextureRect
+
+func _ready() -> void:
+	if slots_parent_path != NodePath():
+		var parent = get_node(slots_parent_path)
+		_slots = parent.get_children()
+		for i in range(_slots.size()):
+			var slot = _slots[i]
+			if slot.has_signal("pressed"):
+				slot.index = i
+				slot.connect("pressed", Callable(self, "_on_slot_pressed").bind(i))
+	_cursor_icon = TextureRect.new()
+	_cursor_icon.visible = false
+	_cursor_icon.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_cursor_icon)
+	set_process(true)
+	visible = false
+
+func bind_player(p) -> void:
+	_player = p
+	_update_known_skills()
+	_update_slots()
+
+func _process(_delta: float) -> void:
+	if _cursor_icon.visible:
+		_cursor_icon.global_position = get_viewport().get_mouse_position()
+
+func open() -> void:
+	_open = true
+	visible = true
+	_update_known_skills()
+	_update_slots()
+	_update_cursor_visibility()
+
+func close() -> void:
+	_open = false
+	visible = false
+	_update_cursor_visibility()
+
+func _update_known_skills() -> void:
+	if not _player or known_skills_parent_path == NodePath():
+		return
+	var parent = get_node(known_skills_parent_path)
+	for child in parent.get_children():
+		child.queue_free()
+	_known_slots.clear()
+	for i in range(_player.known_skills.size()):
+		var skill = _player.known_skills[i]
+		var slot = SkillSlot.new()
+		slot.index = i
+		slot.set_skill(skill)
+		slot.connect("pressed", Callable(self, "_on_known_skill_pressed").bind(slot))
+		parent.add_child(slot)
+		_known_slots.append(slot)
+
+func _update_slots() -> void:
+	if not _player:
+		return
+	for i in range(_slots.size()):
+		var slot = _slots[i]
+		if slot.has_method("set_skill"):
+			slot.set_skill(_player.get_skill_slot(i))
+
+func _on_known_skill_pressed(slot: SkillSlot) -> void:
+	_cursor_skill = slot.skill
+	_update_cursor()
+
+func _on_slot_pressed(index: int) -> void:
+	if not _player:
+		return
+	var existing = _player.get_skill_slot(index)
+	if _cursor_skill:
+		_player.set_skill_slot(index, _cursor_skill)
+		_cursor_skill = existing
+	else:
+		_cursor_skill = existing
+		_player.set_skill_slot(index, null)
+	_update_slots()
+	_update_cursor()
+
+func _update_cursor() -> void:
+	if _cursor_skill:
+		_cursor_icon.texture = _cursor_skill.icon
+	_update_cursor_visibility()
+
+func _update_cursor_visibility() -> void:
+	_cursor_icon.visible = _cursor_skill != null and _open


### PR DESCRIPTION
## Summary
- allow skills to carry an icon for UI display
- introduce `SkillSlot` and `SkillsUI` scripts for assigning known skills to slot buttons
- add new projectile `Fireball` skill resource and script with solar damage and AoE

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e94245b40832dafe5f1b260639bd2