### PR TITLE
Fix constant/class name collisions

### DIFF
--- a/scripts/buff.gd
+++ b/scripts/buff.gd
@@ -1,8 +1,6 @@
 class_name Buff
 extends Resource
 
-const Affix = preload('res://scripts/affix.gd')
-
 @export var duration: float = 0.0
 @export var main_stat_bonuses: Dictionary = {}
 @export var stat_bonuses: Dictionary = {}

--- a/scripts/buff_manager.gd
+++ b/scripts/buff_manager.gd
@@ -1,10 +1,6 @@
 class_name BuffManager
 extends Node
 
-const Buff = preload("res://scripts/buff.gd")
-const Affix = preload("res://scripts/affix.gd")
-const Stats = preload("res://scripts/stats.gd")
-
 var stats: Stats
 var _active: Array = []
 

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -1,10 +1,5 @@
 extends CharacterBody3D
 
-const BuffManager = preload("res://scripts/buff_manager.gd")
-const Buff = preload("res://scripts/buff.gd")
-
-const Stats = preload("res://scripts/stats.gd")
-
 @export var max_health: float = 3.0
 @export var move_speed: float = 2.0
 @export var wander_speed: float = 1.0

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,8 +1,5 @@
 extends CharacterBody3D
 
-const BuffManager = preload("res://scripts/buff_manager.gd")
-const Buff = preload("res://scripts/buff.gd")
-
 @export var move_speed: float = 5.0 # Base move speed before modifiers
 @export var rotation_speed: float = 5.0
 @export var main_skill: Skill = preload("res://resources/skills/holy_smite.tres")

--- a/scripts/skill.gd
+++ b/scripts/skill.gd
@@ -1,8 +1,6 @@
 class_name Skill
 extends Resource
 
-const Stats = preload("res://scripts/stats.gd")
-
 @export var name: String = ""
 @export var icon: Texture2D
 @export var mana_cost: float = 0.0

--- a/scripts/skills/aura_skill.gd
+++ b/scripts/skills/aura_skill.gd
@@ -1,8 +1,6 @@
 extends Skill
 class_name AuraSkill
 
-const Buff = preload("res://scripts/buff.gd")
-
 @export var mana_reserve_percent: float = 0.0 # Percentage of max mana reserved while active
 @export var buff: Buff # Buff applied while aura is active
 @export var aura_effect: PackedScene # Optional visual effect attached to user

--- a/scripts/skills/blast_skill.gd
+++ b/scripts/skills/blast_skill.gd
@@ -1,8 +1,6 @@
 extends Skill
 class_name BlastSkill
 
-const Buff = preload("res://scripts/buff.gd")
-
 @export var radius: float = 3.0 # Base explosion radius
 @export var on_hit_effect: PackedScene # Effect spawned on struck bodies
 @export var explosion_effect: PackedScene # Effect placed at blast center

--- a/scripts/skills/melee_skill.gd
+++ b/scripts/skills/melee_skill.gd
@@ -1,8 +1,6 @@
 extends Skill
 class_name MeleeSkill
 
-const Buff = preload("res://scripts/buff.gd")
-
 @export var range: float = 2.0 # Radius of the swing
 @export var angle: float = 45.0
 @export var on_hit_effect: PackedScene # Effect spawned on struck bodies

--- a/scripts/skills/projectile_skill.gd
+++ b/scripts/skills/projectile_skill.gd
@@ -1,8 +1,6 @@
 extends Skill
 class_name ProjectileSkill
 
-const Buff = preload("res://scripts/buff.gd")
-
 @export var speed: float = 10.0
 @export var range: float = 15.0
 @export var explosion_radius: float = 0.0


### PR DESCRIPTION
## Summary
- remove const declarations that shadow class names like `Buff`, `Affix`, and `Stats`
- rely on globally registered classes for type hints and instantiation

## Testing
- `godot --version` *(fails: command not found)*
- `gdformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ef01cd0e0832db2c50d3959d208e4