### PR TITLE
feat: add rune base damage and affix scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Runes act as itemized mini-skills. Two rune slots combine to create a single abi
 
 Single runes provide basic skills such as **Melee Strike**, **Blessing**, **Area Blast** and **Time Bolt**. Mixing two runes yields combination skills like **Explosive Strike** (Strike+Area), **Enchanted Strike** (Strike+Buff) or **Temporal Aura** (Buff+Time). Runes roll up to three affixes which are combined when the resulting skill is cast.
 
+### Rune Damage
+Runes now define their own base damage range and damage type using the `base_damage_low`, `base_damage_high` and `base_damage_type` fields in their `.tres` files. When runes are combined, each portion of the generated skill uses the base damage and type of its contributing rune. Flat damage affixes on runes apply only to the skill they create, while equipment affixes continue to apply globally to all skills. Damage over time buffs also expose `base_damage_low` and `base_damage_high`, allowing their DPS to be scaled by the caster's stats when applied.
+
+Updated resources:
+- `resources/runes/item_strike_rune.tres`
+- `resources/runes/item_area_rune.tres`
+- `resources/runes/item_time_rune.tres`
+- `resources/runes/item_buff_rune.tres`
+- `resources/skills/rune_time.tres`
+- `resources/skills/rune_strike_time.tres`
+
 ### Adding New Skills
 1. Create a script extending `Skill` (see `scripts/skills/` for examples) and export any parameters you need.
 2. Create a new `.tres` resource in `resources/skills/` that points to the script and assign appropriate tags.
@@ -52,6 +63,7 @@ Generic projectile and blast skills let you assign optional `projectile_scene`, 
 1. Launch the Godot editor and open the project folder.
 2. Press **Play** to run. The player can move and attack.
 3. Use the provided scripts as a starting point for building a larger ARPG.
+4. Run `godot --headless --check` to verify scripts compile after changes.
 
 
 ## Creating Enemy Scenes

--- a/resources/runes/item_area_rune.tres
+++ b/resources/runes/item_area_rune.tres
@@ -15,6 +15,9 @@
 [resource]
 script = ExtResource("3_l3hpt")
 rune_type = 2
+base_damage_low = 1.0
+base_damage_high = 2.0
+base_damage_type = 2
 item_name = "Zone Rune"
 description = "Area-Based Rune"
 icon = ExtResource("10_k7inm")

--- a/resources/runes/item_buff_rune.tres
+++ b/resources/runes/item_buff_rune.tres
@@ -8,6 +8,9 @@
 [resource]
 script = ExtResource("3_s8uqw")
 rune_type = 1
+base_damage_low = 0.0
+base_damage_high = 0.0
+base_damage_type = 0
 item_name = "Buff Rune"
 description = "Applies a buff or debuff to skill"
 icon = ExtResource("3_qyiev")

--- a/resources/runes/item_strike_rune.tres
+++ b/resources/runes/item_strike_rune.tres
@@ -16,6 +16,9 @@
 [resource]
 script = ExtResource("3_jxr7o")
 rune_type = 0
+base_damage_low = 3.0
+base_damage_high = 5.0
+base_damage_type = 0
 item_name = "Strike Rune"
 description = "Melee Strike Rune"
 icon = ExtResource("11_q3hmd")

--- a/resources/runes/item_time_rune.tres
+++ b/resources/runes/item_time_rune.tres
@@ -8,6 +8,9 @@
 [resource]
 script = ExtResource("3_2x7mc")
 rune_type = 3
+base_damage_low = 1.0
+base_damage_high = 2.0
+base_damage_type = 5
 item_name = "Time Rune"
 description = "Changes skill to apply damage over time"
 icon = ExtResource("3_rlpnb")

--- a/resources/skills/rune_strike_time.tres
+++ b/resources/skills/rune_strike_time.tres
@@ -5,7 +5,8 @@
 
 [sub_resource type="Resource" id="Resource_xkkvd"]
 script = ExtResource("1_3p5n5")
-damage_per_second = 1.0
+base_damage_low = 0.0
+base_damage_high = 0.0
 damage_type = 0
 duration = 3.0
 main_stat_bonuses = {}

--- a/resources/skills/rune_time.tres
+++ b/resources/skills/rune_time.tres
@@ -5,7 +5,8 @@
 
 [sub_resource type="Resource" id="Resource_eis8h"]
 script = ExtResource("1_s40xn")
-damage_per_second = 0.0
+base_damage_low = 0.0
+base_damage_high = 0.0
 damage_type = 0
 duration = 0.0
 main_stat_bonuses = {}

--- a/scripts/damage_over_time_buff.gd
+++ b/scripts/damage_over_time_buff.gd
@@ -1,5 +1,10 @@
 class_name DamageOverTimeBuff
 extends Buff
 
-@export var damage_per_second: float = 0.0
+# Base damage range dealt each second before affix modifiers
+@export var base_damage_low: float = 0.0
+@export var base_damage_high: float = 0.0
 @export var damage_type: Stats.DamageType = Stats.DamageType.PHYSICAL
+
+# Final damage per second after modifiers, computed when applied
+var damage_per_second: float = 0.0

--- a/scripts/rune.gd
+++ b/scripts/rune.gd
@@ -9,3 +9,6 @@ extends Item
 enum RuneType { STRIKE, BUFF, AREA, TIME }
 
 @export var rune_type: RuneType = RuneType.STRIKE
+@export var base_damage_low: float = 0.0
+@export var base_damage_high: float = 0.0
+@export var base_damage_type: Stats.DamageType = Stats.DamageType.PHYSICAL

--- a/scripts/rune_skill.gd
+++ b/scripts/rune_skill.gd
@@ -5,18 +5,20 @@ var base_skill: Skill
 var rune_affixes: Array[Affix] = []
 
 func _init(base: Skill = null, affixes: Array[Affix] = []):
-	base_skill = base
-	rune_affixes = affixes
-	if base_skill:
-		name = base_skill.name
-		icon = base_skill.icon
-		mana_cost = base_skill.mana_cost
-		cooldown = base_skill.cooldown
-		duration = base_skill.duration
-		move_multiplier = base_skill.move_multiplier
-		damage_type = base_skill.damage_type
-		tags = base_skill.tags.duplicate()
-	_apply_affix_modifiers()
+        base_skill = base
+        rune_affixes = affixes
+        if base_skill:
+                name = base_skill.name
+                icon = base_skill.icon
+                mana_cost = base_skill.mana_cost
+                cooldown = base_skill.cooldown
+                duration = base_skill.duration
+                move_multiplier = base_skill.move_multiplier
+                damage_type = base_skill.damage_type
+                base_damage_low = base_skill.base_damage_low
+                base_damage_high = base_skill.base_damage_high
+                tags = base_skill.tags.duplicate()
+        _apply_affix_modifiers()
 
 func _apply_affix_modifiers():
 	for a in rune_affixes:

--- a/scripts/rune_skill_factory.gd
+++ b/scripts/rune_skill_factory.gd
@@ -19,7 +19,7 @@ static func build_skill(runes: Array[Rune]) -> Skill:
 	for r in runes:
 		types.append(r.rune_type)
 	types.sort()
-	var base: Skill = null
+        var base: Skill = null
 	match types:
 		[Rune.RuneType.STRIKE]:
 			base = STRIKE_SKILL
@@ -43,9 +43,9 @@ static func build_skill(runes: Array[Rune]) -> Skill:
 			base = AREA_TIME_SKILL
 		_:
 			base = null
-	if base == null:
-		return null
-	var affixes: Array[Affix] = []
+        if base == null:
+                return null
+        var affixes: Array[Affix] = []
 	if types == [Rune.RuneType.BUFF, Rune.RuneType.TIME]:
 		for r in runes:
 			for a in r.affixes:
@@ -61,7 +61,62 @@ static func build_skill(runes: Array[Rune]) -> Skill:
 						continue
 				affixes.append(a)
 	else:
-		for r in runes:
-			affixes += r.affixes
-	var skill = RuneSkill.new(base.duplicate(true), affixes)
-	return skill
+                for r in runes:
+                        affixes += r.affixes
+        var base_skill: Skill = base.duplicate(true)
+        _apply_base_damage(base_skill, runes)
+        var skill = RuneSkill.new(base_skill, affixes)
+        return skill
+
+
+static func _apply_base_damage(skill: Skill, runes: Array[Rune]) -> void:
+        var rune_map: Dictionary = {}
+        for r in runes:
+                rune_map[r.rune_type] = r
+        if skill is ComboSkill:
+                for s in skill.skills:
+                        _apply_base_damage(s, runes)
+                return
+        if skill is MeleeSkill:
+                var sr: Rune = rune_map.get(Rune.RuneType.STRIKE, null)
+                if sr:
+                        skill.base_damage_low = sr.base_damage_low
+                        skill.base_damage_high = sr.base_damage_high
+                        skill.damage_type = sr.base_damage_type
+                if not skill.tags.has("Melee"):
+                        skill.tags.append("Melee")
+                if skill.on_hit_buff is DamageOverTimeBuff and rune_map.has(Rune.RuneType.TIME):
+                        var tr: Rune = rune_map[Rune.RuneType.TIME]
+                        skill.on_hit_buff.base_damage_low = tr.base_damage_low
+                        skill.on_hit_buff.base_damage_high = tr.base_damage_high
+                        skill.on_hit_buff.damage_type = tr.base_damage_type
+        elif skill is BlastSkill:
+                var ar: Rune = rune_map.get(Rune.RuneType.AREA, null)
+                if ar:
+                        skill.base_damage_low = ar.base_damage_low
+                        skill.base_damage_high = ar.base_damage_high
+                        skill.damage_type = ar.base_damage_type
+                elif rune_map.has(Rune.RuneType.TIME):
+                        var tr: Rune = rune_map[Rune.RuneType.TIME]
+                        skill.base_damage_low = tr.base_damage_low
+                        skill.base_damage_high = tr.base_damage_high
+                        skill.damage_type = tr.base_damage_type
+                if not skill.tags.has("Spell"):
+                        skill.tags.append("Spell")
+                if skill.on_hit_buff is DamageOverTimeBuff and rune_map.has(Rune.RuneType.TIME):
+                        var tr2: Rune = rune_map[Rune.RuneType.TIME]
+                        skill.on_hit_buff.base_damage_low = tr2.base_damage_low
+                        skill.on_hit_buff.base_damage_high = tr2.base_damage_high
+                        skill.on_hit_buff.damage_type = tr2.base_damage_type
+        elif skill is ProjectileSkill:
+                var tr3: Rune = rune_map.get(Rune.RuneType.TIME, null)
+                if tr3:
+                        skill.base_damage_low = tr3.base_damage_low
+                        skill.base_damage_high = tr3.base_damage_high
+                        skill.damage_type = tr3.base_damage_type
+                if not skill.tags.has("Spell"):
+                        skill.tags.append("Spell")
+                if skill.on_hit_buff is DamageOverTimeBuff and tr3:
+                        skill.on_hit_buff.base_damage_low = tr3.base_damage_low
+                        skill.on_hit_buff.base_damage_high = tr3.base_damage_high
+                        skill.on_hit_buff.damage_type = tr3.base_damage_type

--- a/scripts/skill.gd
+++ b/scripts/skill.gd
@@ -8,6 +8,8 @@ extends Resource
 @export var duration: float = 0.0
 @export var move_multiplier: float = 1.0
 @export var damage_type: Stats.DamageType = Stats.DamageType.PHYSICAL
+@export var base_damage_low: float = 0.0
+@export var base_damage_high: float = 0.0
 @export var tags: Array[String] = []
 
 func perform(user):

--- a/scripts/skills/melee_skill.gd
+++ b/scripts/skills/melee_skill.gd
@@ -43,18 +43,24 @@ func perform(user):
 		params.shape = shape
 		params.transform = attack_area.global_transform
 		params.collide_with_bodies = true
-		var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
-		var dmg_map = user.stats.get_all_damage(tags)
-		for result in bodies:
-				var body = result.get("collider")
-				if body and body.has_method("take_damage"):
-						if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
-								for dt in dmg_map.keys():
-										var dmg = dmg_map[dt]
-										if dmg > 0:
-												body.take_damage(dmg, dt)
-								if on_hit_buff and body.has_method("add_buff"):
-										body.add_buff(on_hit_buff)
-								if on_hit_effect:
-										var eff = on_hit_effect.instantiate()
-										body.add_child(eff)
+                var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
+                var base_dict = {damage_type: Vector2(base_damage_low, base_damage_high)}
+                var dmg_map = user.stats.compute_damage(base_dict, tags)
+                for result in bodies:
+                                var body = result.get("collider")
+                                if body and body.has_method("take_damage"):
+                                                if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
+                                                                for dt in dmg_map.keys():
+                                                                                var dmg = dmg_map[dt]
+                                                                                if dmg > 0:
+                                                                                                body.take_damage(dmg, dt)
+                                                                if on_hit_buff and body.has_method("add_buff"):
+                                                                                var b = on_hit_buff.duplicate(true)
+                                                                                if b is DamageOverTimeBuff:
+                                                                                                var dot_dict = {b.damage_type: Vector2(b.base_damage_low, b.base_damage_high)}
+                                                                                                var dot_map = user.stats.compute_damage(dot_dict, tags)
+                                                                                                b.damage_per_second = dot_map[b.damage_type]
+                                                                                body.add_buff(b)
+                                                                if on_hit_effect:
+                                                                                var eff = on_hit_effect.instantiate()
+                                                                                body.add_child(eff)

--- a/scripts/skills/projectile_skill.gd
+++ b/scripts/skills/projectile_skill.gd
@@ -43,17 +43,23 @@ func _create_projectile():
 
 func _on_projectile_body_entered(body, projectile, user):
 		if body and body.has_method("take_damage"):
-				if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
-						var dmg_map = user.stats.get_all_damage(tags)
-						for dt in dmg_map.keys():
-								var dmg = dmg_map[dt]
-								if dmg > 0:
-										body.take_damage(dmg, dt)
-						if on_hit_buff and body.has_method("add_buff"):
-								body.add_buff(on_hit_buff)
-						if on_hit_effect:
-								var eff = on_hit_effect.instantiate()
-								body.add_child(eff)
+                                if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
+                                                var base_dict = {damage_type: Vector2(base_damage_low, base_damage_high)}
+                                                var dmg_map = user.stats.compute_damage(base_dict, tags)
+                                                for dt in dmg_map.keys():
+                                                                var dmg = dmg_map[dt]
+                                                                if dmg > 0:
+                                                                                body.take_damage(dmg, dt)
+                                                if on_hit_buff and body.has_method("add_buff"):
+                                                                var b = on_hit_buff.duplicate(true)
+                                                                if b is DamageOverTimeBuff:
+                                                                                var dot_dict = {b.damage_type: Vector2(b.base_damage_low, b.base_damage_high)}
+                                                                                var dot_map = user.stats.compute_damage(dot_dict, tags)
+                                                                                b.damage_per_second = dot_map[b.damage_type]
+                                                                body.add_buff(b)
+                                                if on_hit_effect:
+                                                                var eff = on_hit_effect.instantiate()
+                                                                body.add_child(eff)
 		_explode(projectile.global_transform.origin, user)
 		projectile.queue_free()
 
@@ -75,21 +81,27 @@ func _explode(origin: Vector3, user):
 		params.shape = shape
 		params.transform = Transform3D(Basis(), origin)
 		params.collide_with_bodies = true
-		var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
-		var dmg_map = user.stats.get_all_damage(tags)
-		for result in bodies:
-				var body = result.get("collider")
-				if body and body.has_method("take_damage"):
-						if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
-								for dt in dmg_map.keys():
-										var dmg = dmg_map[dt]
-										if dmg > 0:
-												body.take_damage(dmg, dt)
-								if on_hit_buff and body.has_method("add_buff"):
-										body.add_buff(on_hit_buff)
-								if on_hit_effect:
-										var eff = on_hit_effect.instantiate()
-										body.add_child(eff)
+                var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
+                var base_dict = {damage_type: Vector2(base_damage_low, base_damage_high)}
+                var dmg_map = user.stats.compute_damage(base_dict, tags)
+                for result in bodies:
+                                var body = result.get("collider")
+                                if body and body.has_method("take_damage"):
+                                                if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
+                                                                for dt in dmg_map.keys():
+                                                                                var dmg = dmg_map[dt]
+                                                                                if dmg > 0:
+                                                                                                body.take_damage(dmg, dt)
+                                                                if on_hit_buff and body.has_method("add_buff"):
+                                                                                var b = on_hit_buff.duplicate(true)
+                                                                                if b is DamageOverTimeBuff:
+                                                                                                var dot_dict = {b.damage_type: Vector2(b.base_damage_low, b.base_damage_high)}
+                                                                                                var dot_map = user.stats.compute_damage(dot_dict, tags)
+                                                                                                b.damage_per_second = dot_map[b.damage_type]
+                                                                                body.add_buff(b)
+                                                                if on_hit_effect:
+                                                                                var eff = on_hit_effect.instantiate()
+                                                                                body.add_child(eff)
 		if explosion_effect:
 				var e = explosion_effect.instantiate()
 				e.global_transform.origin = origin

--- a/scripts/stats.gd
+++ b/scripts/stats.gd
@@ -180,10 +180,26 @@ func get_damage(damage_type: DamageType = DamageType.PHYSICAL, tags: Array[Strin
 								return _compute_stat_tagged(base_damage.get(damage_type, 0.0), key, tags)
 
 func get_all_damage(tags: Array[String] = []) -> Dictionary:
-				var result: Dictionary = {}
-				for dt in DAMAGE_TYPES:
-								result[dt] = get_damage(dt, tags)
-				return result
+        return compute_damage({}, tags)
+
+
+func compute_damage(extra_base: Dictionary, tags: Array[String] = []) -> Dictionary:
+        # Calculates total damage per type using the actor's base damage
+        # plus any additional `extra_base` provided by skills. Values in
+        # `extra_base` should be Vector2 ranges representing min/max
+        # damage to roll.
+        var result: Dictionary = {}
+        for dt in DAMAGE_TYPES:
+                var base_val: float = base_damage.get(dt, 0.0)
+                if extra_base.has(dt):
+                        var val = extra_base[dt]
+                        if typeof(val) == TYPE_VECTOR2:
+                                base_val += randf_range(val.x, val.y)
+                        else:
+                                base_val += float(val)
+                var key = "%s_damage" % DAMAGE_TYPE_KEYS[dt]
+                result[dt] = _compute_stat_tagged(base_val, key, tags)
+        return result
 
 
 func get_move_speed() -> float:


### PR DESCRIPTION
## Summary
- allow runes to specify base damage ranges and types
- compute damage from rune skills using new stats helpers
- document rune damage setup and affected resources

## Testing
- `godot --headless --check` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_689146cad2dc832d979dd067f9a97068