### PR TITLE
Snapshot damage at cast time

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Updated resources:
 - `resources/skills/rune_time.tres`
 - `resources/skills/rune_strike_time.tres`
 
+### Damage Snapshotting
+Projectile, melee and blast skills now roll and store their damage when cast.
+This snapshot allows projectiles and delayed explosions to apply the correct
+damage even if the caster dies before they land. When creating or editing a
+skill `.tres` resource, make sure its `base_damage_low`, `base_damage_high` and
+`damage_type` fields are set so the snapshot has values to roll. If you want
+custom visual effects or projectile scenes, create a new `.tscn` in the editor
+and assign it to the skill's exported `projectile_scene`, `on_hit_effect` or
+`explosion_effect` properties.
+
 ### Adding New Skills
 1. Create a script extending `Skill` (see `scripts/skills/` for examples) and export any parameters you need.
 2. Create a new `.tres` resource in `resources/skills/` that points to the script and assign appropriate tags.

--- a/scripts/skills/blast_skill.gd
+++ b/scripts/skills/blast_skill.gd
@@ -7,11 +7,11 @@ class_name BlastSkill
 @export var on_hit_buff: Buff # Buff or debuff applied to bodies hit
 
 func perform(user):
-	if user == null:
-		return
-	var camera = user.get_viewport().get_camera_3d()
-	if camera == null:
-		return
+        if user == null:
+                return
+        var camera = user.get_viewport().get_camera_3d()
+        if camera == null:
+                return
 	var mouse_pos = user.get_viewport().get_mouse_position()
 	var ray_origin = camera.project_ray_origin(mouse_pos)
 	var ray_dir = camera.project_ray_normal(mouse_pos)
@@ -19,41 +19,46 @@ func perform(user):
 	if abs(ray_dir.y) <= 0.0001:
 		return
 	var distance = (plane_y - ray_origin.y) / ray_dir.y
-	var target = ray_origin + ray_dir * distance
-	_explode(target, user)
+       var target = ray_origin + ray_dir * distance
+       # Snapshot values before the user might die
+       var base_dict = _build_base_damage_dict(user)
+       var dmg_map = user.stats.compute_damage(base_dict, tags)
+       var buff_snapshot
+       if on_hit_buff:
+               buff_snapshot = on_hit_buff.duplicate(true)
+               if buff_snapshot is DamageOverTimeBuff:
+                       var dot_dict = {buff_snapshot.damage_type: Vector2(buff_snapshot.base_damage_low, buff_snapshot.base_damage_high)}
+                       var dot_map = user.stats.compute_damage(dot_dict, tags)
+                       buff_snapshot.damage_per_second = dot_map[buff_snapshot.damage_type]
+       var is_player = user.is_in_group("player")
+       var mult = user.stats.get_aoe_multiplier()
+       var world = user.get_world_3d()
+       var parent = user.get_parent()
+       _explode(target, parent, world, dmg_map, buff_snapshot, mult, is_player)
 
-func _explode(origin: Vector3, user):
-	var mult = user.stats.get_aoe_multiplier()
-	var shape = SphereShape3D.new()
-	shape.radius = radius * mult
-	var params = PhysicsShapeQueryParameters3D.new()
-	params.shape = shape
-	params.transform = Transform3D(Basis(), origin)
-	params.collide_with_bodies = true
-	var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
-	   # Combine any innate user damage with the skill's base values.
-	var base_dict = _build_base_damage_dict(user)
-	var dmg_map = user.stats.compute_damage(base_dict, tags)
-	for result in bodies:
-		var body = result.get("collider")
-		if body and body.has_method("take_damage"):
-			if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
-				for dt in dmg_map.keys():
-					var dmg = dmg_map[dt]
-					if dmg > 0:
-						body.take_damage(dmg, dt)
-				if on_hit_buff and body.has_method("add_buff"):
-					var b = on_hit_buff.duplicate(true)
-					if b is DamageOverTimeBuff:
-						var dot_dict = {b.damage_type: Vector2(b.base_damage_low, b.base_damage_high)}
-						var dot_map = user.stats.compute_damage(dot_dict, tags)
-						b.damage_per_second = dot_map[b.damage_type]
-					body.add_buff(b)
-				if on_hit_effect:
-					var eff = on_hit_effect.instantiate()
-					body.add_child(eff)
-	if explosion_effect:
-		var e = explosion_effect.instantiate()
-		e.global_transform.origin = origin
-		e.scale = Vector3.ONE * radius * mult
-		user.get_parent().add_child(e)
+func _explode(origin: Vector3, parent, world, dmg_map, buff_snapshot, mult, is_player):
+       var shape = SphereShape3D.new()
+       shape.radius = radius * mult
+       var params = PhysicsShapeQueryParameters3D.new()
+       params.shape = shape
+       params.transform = Transform3D(Basis(), origin)
+       params.collide_with_bodies = true
+       var bodies = world.direct_space_state.intersect_shape(params)
+       for result in bodies:
+               var body = result.get("collider")
+               if body and body.has_method("take_damage"):
+                       if (is_player and body.is_in_group("enemy")) or (not is_player and body.is_in_group("player")):
+                               for dt in dmg_map.keys():
+                                       var dmg = dmg_map[dt]
+                                       if dmg > 0:
+                                               body.take_damage(dmg, dt)
+                               if buff_snapshot and body.has_method("add_buff"):
+                                       body.add_buff(buff_snapshot.duplicate(true))
+                               if on_hit_effect:
+                                       var eff = on_hit_effect.instantiate()
+                                       body.add_child(eff)
+       if explosion_effect:
+               var e = explosion_effect.instantiate()
+               e.global_transform.origin = origin
+               e.scale = Vector3.ONE * radius * mult
+               parent.add_child(e)

--- a/scripts/skills/melee_skill.gd
+++ b/scripts/skills/melee_skill.gd
@@ -7,14 +7,14 @@ class_name MeleeSkill
 @export var on_hit_buff: Buff # Buff or debuff applied to bodies hit
 
 func perform(user):
-	if user == null:
-		return
-	var direction: Vector3
-	if user.has_method("_get_click_direction"):
-		direction = user._get_click_direction()
-	else:
-		direction = -user.global_transform.basis.z
-	user.look_at(user.global_transform.origin + direction, Vector3.UP)
+        if user == null:
+                return
+        var direction: Vector3
+        if user.has_method("_get_click_direction"):
+                direction = user._get_click_direction()
+        else:
+                direction = -user.global_transform.basis.z
+        user.look_at(user.global_transform.origin + direction, Vector3.UP)
 	var attack_area = Area3D.new()
 	var shape = CylinderShape3D.new()
 	shape.height = 1.0
@@ -39,29 +39,32 @@ func perform(user):
 	timer.autostart = true
 	timer.connect("timeout", Callable(attack_area, "queue_free"))
 	attack_area.add_child(timer)
-	var params = PhysicsShapeQueryParameters3D.new()
-	params.shape = shape
-	params.transform = attack_area.global_transform
-	params.collide_with_bodies = true
-	var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
-# Combine the user's innate damage (if any) with the skill's base # damage before computing final values.
-	var base_dict = _build_base_damage_dict(user)
-	var dmg_map = user.stats.compute_damage(base_dict, tags)
-	for result in bodies:
-		var body = result.get("collider")
-		if body and body.has_method("take_damage"):
-			if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
-				for dt in dmg_map.keys():
-					var dmg = dmg_map[dt]
-					if dmg > 0:
-						body.take_damage(dmg, dt)
-				if on_hit_buff and body.has_method("add_buff"):
-					var b = on_hit_buff.duplicate(true)
-					if b is DamageOverTimeBuff:
-						var dot_dict = {b.damage_type: Vector2(b.base_damage_low, b.base_damage_high)}
-						var dot_map = user.stats.compute_damage(dot_dict, tags)
-						b.damage_per_second = dot_map[b.damage_type]
-					body.add_buff(b)
-				if on_hit_effect:
-					var eff = on_hit_effect.instantiate()
-					body.add_child(eff)
+       var params = PhysicsShapeQueryParameters3D.new()
+       params.shape = shape
+       params.transform = attack_area.global_transform
+       params.collide_with_bodies = true
+       var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
+       # Snapshot damage and team info so hits remain valid if the user dies mid‑attack
+       var base_dict = _build_base_damage_dict(user)
+       var dmg_map = user.stats.compute_damage(base_dict, tags)
+       var buff_snapshot
+       if on_hit_buff:
+               buff_snapshot = on_hit_buff.duplicate(true)
+               if buff_snapshot is DamageOverTimeBuff:
+                       var dot_dict = {buff_snapshot.damage_type: Vector2(buff_snapshot.base_damage_low, buff_snapshot.base_damage_high)}
+                       var dot_map = user.stats.compute_damage(dot_dict, tags)
+                       buff_snapshot.damage_per_second = dot_map[buff_snapshot.damage_type]
+       var is_player = user.is_in_group("player")
+       for result in bodies:
+               var body = result.get("collider")
+               if body and body.has_method("take_damage"):
+                       if (is_player and body.is_in_group("enemy")) or (not is_player and body.is_in_group("player")):
+                               for dt in dmg_map.keys():
+                                       var dmg = dmg_map[dt]
+                                       if dmg > 0:
+                                               body.take_damage(dmg, dt)
+                               if buff_snapshot and body.has_method("add_buff"):
+                                       body.add_buff(buff_snapshot.duplicate(true))
+                               if on_hit_effect:
+                                       var eff = on_hit_effect.instantiate()
+                                       body.add_child(eff)

--- a/scripts/skills/projectile_skill.gd
+++ b/scripts/skills/projectile_skill.gd
@@ -10,22 +10,36 @@ class_name ProjectileSkill
 @export var on_hit_buff: Buff # Buff or debuff applied to bodies hit
 
 func perform(user):
-	if user == null:
-		return
-	var direction: Vector3
-	if user.has_method("_get_click_direction"):
-		direction = user._get_click_direction()
-	else:
-		direction = -user.global_transform.basis.z
-	user.look_at(user.global_transform.origin + direction, Vector3.UP)
-	var projectile = _create_projectile()
-	projectile.body_entered.connect(_on_projectile_body_entered.bind(projectile, user))
-	user.get_parent().add_child(projectile)
-	projectile.global_transform.origin = user.global_transform.origin + direction
-	var travel_time = range / speed
-	var tween = projectile.create_tween()
-	tween.tween_property(projectile, "global_transform:origin", user.global_transform.origin + direction * range, travel_time)
-	tween.connect("finished", Callable(self, "_on_projectile_finished").bind(projectile, user))
+        if user == null:
+                return
+        var direction: Vector3
+        if user.has_method("_get_click_direction"):
+                direction = user._get_click_direction()
+        else:
+                direction = -user.global_transform.basis.z
+        user.look_at(user.global_transform.origin + direction, Vector3.UP)
+       var projectile = _create_projectile()
+       # Snapshot all values needed so the projectile can resolve damage even if the user dies
+       var base_dict = _build_base_damage_dict(user)
+       var dmg_map = user.stats.compute_damage(base_dict, tags)
+       var buff_snapshot
+       if on_hit_buff:
+               buff_snapshot = on_hit_buff.duplicate(true)
+               if buff_snapshot is DamageOverTimeBuff:
+                       var dot_dict = {buff_snapshot.damage_type: Vector2(buff_snapshot.base_damage_low, buff_snapshot.base_damage_high)}
+                       var dot_map = user.stats.compute_damage(dot_dict, tags)
+                       buff_snapshot.damage_per_second = dot_map[buff_snapshot.damage_type]
+       projectile.set_meta("dmg_map", dmg_map)
+       projectile.set_meta("buff_snapshot", buff_snapshot)
+       projectile.set_meta("aoe_mult", user.stats.get_aoe_multiplier())
+       projectile.set_meta("is_player", user.is_in_group("player"))
+       projectile.body_entered.connect(_on_projectile_body_entered.bind(projectile))
+       user.get_parent().add_child(projectile)
+       projectile.global_transform.origin = user.global_transform.origin + direction
+       var travel_time = range / speed
+       var tween = projectile.create_tween()
+       tween.tween_property(projectile, "global_transform:origin", user.global_transform.origin + direction * range, travel_time)
+       tween.connect("finished", Callable(self, "_on_projectile_finished").bind(projectile))
 
 func _create_projectile():
 	if projectile_scene:
@@ -41,71 +55,62 @@ func _create_projectile():
 	p.add_child(mesh)
 	return p
 
-func _on_projectile_body_entered(body, projectile, user):
-	if body and body.has_method("take_damage"):
-		if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
-											   # Merge user's base damage with the skill's own values.
-			var base_dict = _build_base_damage_dict(user)
-			var dmg_map = user.stats.compute_damage(base_dict, tags)
-			for dt in dmg_map.keys():
-				var dmg = dmg_map[dt]
-				if dmg > 0:
-					body.take_damage(dmg, dt)
-			if on_hit_buff and body.has_method("add_buff"):
-				var b = on_hit_buff.duplicate(true)
-				if b is DamageOverTimeBuff:
-					var dot_dict = {b.damage_type: Vector2(b.base_damage_low, b.base_damage_high)}
-					var dot_map = user.stats.compute_damage(dot_dict, tags)
-					b.damage_per_second = dot_map[b.damage_type]
-				body.add_buff(b)
-			if on_hit_effect:
-				var eff = on_hit_effect.instantiate()
-				body.add_child(eff)
-	_explode(projectile.global_transform.origin, user)
-	projectile.queue_free()
+func _on_projectile_body_entered(body, projectile):
+       if body and body.has_method("take_damage"):
+               var is_player = projectile.get_meta("is_player")
+               if (is_player and body.is_in_group("enemy")) or (not is_player and body.is_in_group("player")):
+                       var dmg_map = projectile.get_meta("dmg_map")
+                       for dt in dmg_map.keys():
+                               var dmg = dmg_map[dt]
+                               if dmg > 0:
+                                       body.take_damage(dmg, dt)
+                       var buff_snapshot = projectile.get_meta("buff_snapshot")
+                       if buff_snapshot and body.has_method("add_buff"):
+                               body.add_buff(buff_snapshot.duplicate(true))
+                       if on_hit_effect:
+                               var eff = on_hit_effect.instantiate()
+                               body.add_child(eff)
+       _explode(projectile)
+       projectile.queue_free()
 
-func _on_projectile_finished(projectile, user):
-	_explode(projectile.global_transform.origin, user)
-	projectile.queue_free()
+func _on_projectile_finished(projectile):
+       _explode(projectile)
+       projectile.queue_free()
 
-func _explode(origin: Vector3, user):
-	if explosion_radius <= 0.0:
-		if explosion_effect:
-			var eff = explosion_effect.instantiate()
-			eff.global_transform.origin = origin
-			user.get_parent().add_child(eff)
-		return
-	var mult = user.stats.get_aoe_multiplier()
-	var shape = SphereShape3D.new()
-	shape.radius = explosion_radius * mult
-	var params = PhysicsShapeQueryParameters3D.new()
-	params.shape = shape
-	params.transform = Transform3D(Basis(), origin)
-	params.collide_with_bodies = true
-	var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
-	   # Merge the user's base damage with the skill's own when exploding.
-	var base_dict = _build_base_damage_dict(user)
-	var dmg_map = user.stats.compute_damage(base_dict, tags)
-	for result in bodies:
-		var body = result.get("collider")
-		if body and body.has_method("take_damage"):
-			if user.is_in_group("player") and body.is_in_group("enemy") or user.is_in_group("enemy") and body.is_in_group("player"):
-				for dt in dmg_map.keys():
-					var dmg = dmg_map[dt]
-					if dmg > 0:
-						body.take_damage(dmg, dt)
-				if on_hit_buff and body.has_method("add_buff"):
-					var b = on_hit_buff.duplicate(true)
-					if b is DamageOverTimeBuff:
-						var dot_dict = {b.damage_type: Vector2(b.base_damage_low, b.base_damage_high)}
-						var dot_map = user.stats.compute_damage(dot_dict, tags)
-						b.damage_per_second = dot_map[b.damage_type]
-					body.add_buff(b)
-				if on_hit_effect:
-					var eff = on_hit_effect.instantiate()
-					body.add_child(eff)
-	if explosion_effect:
-		var e = explosion_effect.instantiate()
-		e.global_transform.origin = origin
-		e.scale = Vector3.ONE * explosion_radius * mult
-		user.get_parent().add_child(e)
+func _explode(projectile):
+       var origin = projectile.global_transform.origin
+       if explosion_radius <= 0.0:
+               if explosion_effect:
+                       var eff = explosion_effect.instantiate()
+                       eff.global_transform.origin = origin
+                       projectile.get_parent().add_child(eff)
+               return
+       var mult = projectile.get_meta("aoe_mult")
+       var shape = SphereShape3D.new()
+       shape.radius = explosion_radius * mult
+       var params = PhysicsShapeQueryParameters3D.new()
+       params.shape = shape
+       params.transform = Transform3D(Basis(), origin)
+       params.collide_with_bodies = true
+       var bodies = projectile.get_world_3d().direct_space_state.intersect_shape(params)
+       var dmg_map = projectile.get_meta("dmg_map")
+       var buff_snapshot = projectile.get_meta("buff_snapshot")
+       var is_player = projectile.get_meta("is_player")
+       for result in bodies:
+               var body = result.get("collider")
+               if body and body.has_method("take_damage"):
+                       if (is_player and body.is_in_group("enemy")) or (not is_player and body.is_in_group("player")):
+                               for dt in dmg_map.keys():
+                                       var dmg = dmg_map[dt]
+                                       if dmg > 0:
+                                               body.take_damage(dmg, dt)
+                               if buff_snapshot and body.has_method("add_buff"):
+                                       body.add_buff(buff_snapshot.duplicate(true))
+                               if on_hit_effect:
+                                       var eff = on_hit_effect.instantiate()
+                                       body.add_child(eff)
+       if explosion_effect:
+               var e = explosion_effect.instantiate()
+               e.global_transform.origin = origin
+               e.scale = Vector3.ONE * explosion_radius * mult
+               projectile.get_parent().add_child(e)


### PR DESCRIPTION
## Summary
- snapshot all damage values when a skill is cast so projectiles and delayed explosions no longer depend on the caster
- document the new snapshotting behaviour and how to configure skill resources

## Testing
- `godot --headless --check` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689238180250832db9a4c3b68931b6e8