### PR TITLE
Add zone shard and level generation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,19 @@ instance is spawned for successful rolls.
 3. The player scene automatically belongs to the **"players"** group so enemies
    will find it without additional setup.
 
+
+## Zone Shards and Level Generation
+Zone Shards are consumable items that open a temporary zone. They reuse the existing affix framework so shards can roll modifiers that influence the generated level.
+
+### Creating Zone Shards
+1. Create a new resource using **ZoneShard** (`scripts/items/zone_shard.gd`).
+2. Assign an icon and optional description.
+3. Populate `affix_pool` with zone affix definitions such as:
+   - `resources/affixes/zone/enemy_spawn_inc.tres` – increases number of enemy packs.
+   - `resources/affixes/zone/enemy_fire_damage.tres` – adds flat fire damage to enemies.
+   - `resources/affixes/zone/enemy_hp_inc.tres` – increases enemy life.
+
+Example: `resources/items/zone_shard.tres` shows a shard configured with these affixes. Zone Shards can be rerolled with Chaos Orbs like any other item.
+
+### Generating a Zone
+Attach `scripts/ui/zone_shard_slot.gd` to a `Control` that contains an `InventorySlot` for the shard and a `Button` to trigger the run. Export `zone_generator` to a `ZoneGenerator` resource (`scripts/zones/zone_generator.gd`) and set its `enemy_pack_scene` and `boss_scene` in the editor. When the button is pressed the control emits `zone_generated(PackedScene)`; instance this scene and warp the player to begin the encounter.

--- a/resources/affixes/zone/enemy_fire_damage.tres
+++ b/resources/affixes/zone/enemy_fire_damage.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="AffixDefinition" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/items/affix_definition.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+name = "Added Fire Damage to Enemies"
+description = "{value} added fire damage to enemies"
+stat_key = "enemy_fire_damage"
+tiers = [Vector2(3,5), Vector2(1,3)]

--- a/resources/affixes/zone/enemy_hp_inc.tres
+++ b/resources/affixes/zone/enemy_hp_inc.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="AffixDefinition" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/items/affix_definition.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+name = "Increased Enemy Life"
+description = "{value}% increased enemy life"
+stat_key = "enemy_hp_inc"
+tiers = [Vector2(30,40), Vector2(20,30), Vector2(10,20)]

--- a/resources/affixes/zone/enemy_spawn_inc.tres
+++ b/resources/affixes/zone/enemy_spawn_inc.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="AffixDefinition" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/items/affix_definition.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+name = "Increased Enemy Spawns"
+description = "{value}% increased enemy spawns"
+stat_key = "enemy_spawn_inc"
+tiers = [Vector2(20,30), Vector2(10,20), Vector2(5,10)]

--- a/resources/items/zone_shard.tres
+++ b/resources/items/zone_shard.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="ZoneShard" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/items/zone_shard.gd" id="1"]
+[ext_resource type="Texture2D" path="res://images/test_item.png" id="2"]
+[ext_resource type="Resource" path="res://resources/affixes/zone/enemy_spawn_inc.tres" id="3"]
+[ext_resource type="Resource" path="res://resources/affixes/zone/enemy_fire_damage.tres" id="4"]
+[ext_resource type="Resource" path="res://resources/affixes/zone/enemy_hp_inc.tres" id="5"]
+
+[resource]
+script = ExtResource("1")
+item_name = "Zone Shard"
+description = "Opens a random zone"
+icon = ExtResource("2")
+affix_pool = [ExtResource("3"), ExtResource("4"), ExtResource("5")]
+max_stack = 20

--- a/resources/zones/default_zone_generator.tres
+++ b/resources/zones/default_zone_generator.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="ZoneGenerator" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/zones/zone_generator.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+base_pack_count = 5
+plane_size = 20.0

--- a/scripts/items/zone_shard.gd
+++ b/scripts/items/zone_shard.gd
@@ -1,0 +1,13 @@
+class_name ZoneShard
+extends Item
+
+# Zone shards open a generated level when placed in a ZoneShardSlot and
+# activated.  They reuse the standard item/affix system so they can roll
+# modifiers that affect the zone.
+#
+# The actual level is produced by `ZoneGenerator.generate_zone` which reads the
+# affixes on the shard and builds a PackedScene.
+
+# Optional description of the zone tier or tileset that could be used when
+# generating the level.  For now this is informational only.
+@export var zone_type: String = ""

--- a/scripts/ui/inventory_ui.gd
+++ b/scripts/ui/inventory_ui.gd
@@ -308,6 +308,16 @@ func pickup_to_cursor(item: Item, amount: int) -> void:
 	_cursor_amount = amount
 	_update_cursor()
 
+func get_cursor_item() -> Item:
+        return _cursor_item
+
+func take_cursor_item() -> Dictionary:
+        var data = {"item": _cursor_item, "amount": _cursor_amount}
+        _cursor_item = null
+        _cursor_amount = 0
+        _update_cursor()
+        return data
+
 
 func _update_cursor() -> void:
 	if _cursor_item:

--- a/scripts/ui/zone_shard_slot.gd
+++ b/scripts/ui/zone_shard_slot.gd
@@ -1,0 +1,53 @@
+class_name ZoneShardSlot
+extends Control
+
+# UI control containing a single InventorySlot for inserting a ZoneShard and a
+# button to generate a zone from it.
+
+signal zone_generated(scene: PackedScene)
+
+@export var inventory_ui_path: NodePath
+@export var shard_slot_path: NodePath
+@export var go_button_path: NodePath
+@export var zone_generator: ZoneGenerator
+
+var _inventory_ui: InventoryUI
+var _slot: InventorySlot
+var _go_button: Button
+
+func _ready() -> void:
+    _inventory_ui = get_node_or_null(inventory_ui_path)
+    _slot = get_node(shard_slot_path)
+    _go_button = get_node(go_button_path)
+    _slot.pressed.connect(_on_slot_pressed)
+    _go_button.pressed.connect(_on_go_pressed)
+    _update_button()
+
+func _on_slot_pressed(_index: int) -> void:
+    if not _inventory_ui:
+        return
+    var cursor_item: Item = _inventory_ui.get_cursor_item()
+    if cursor_item:
+        if cursor_item is ZoneShard:
+            var payload = _inventory_ui.take_cursor_item()
+            _slot.set_item(payload["item"])
+            _slot.set_amount(1)
+        # ignore non ZoneShard items
+    elif _slot.item:
+        var item = _slot.item
+        _slot.set_item(null)
+        _slot.set_amount(0)
+        _inventory_ui.pickup_to_cursor(item, 1)
+    _update_button()
+
+func _on_go_pressed() -> void:
+    if _slot.item and zone_generator:
+        var scene = zone_generator.generate_zone([_slot.item])
+        emit_signal("zone_generated", scene)
+        _slot.set_item(null)
+        _slot.set_amount(0)
+    _update_button()
+
+func _update_button() -> void:
+    if _go_button:
+        _go_button.disabled = _slot.item == null

--- a/scripts/zones/generated_zone.gd
+++ b/scripts/zones/generated_zone.gd
@@ -1,0 +1,28 @@
+class_name GeneratedZone
+extends Node3D
+
+# Holds a dictionary of modifiers derived from the Zone Shards used to open
+# this zone.  When the zone enters the scene tree it applies the modifiers to
+# all enemy instances under it.
+
+var mods: Dictionary = {}
+
+const Stats = preload("res://scripts/stats.gd")
+
+func _ready() -> void:
+    _apply_mods()
+
+func _apply_mods() -> void:
+    for enemy in get_tree().get_nodes_in_group("enemy"):
+        if enemy.is_inside_tree() and is_ancestor_of(enemy):
+            _apply_enemy_mods(enemy)
+
+func _apply_enemy_mods(enemy) -> void:
+    var hp_inc := mods.get("enemy_hp_inc", 0.0)
+    if hp_inc != 0.0:
+        enemy.stats.base_max_health *= 1.0 + hp_inc / 100.0
+        enemy.max_health = enemy.stats.get_max_health()
+        enemy.current_health = enemy.max_health
+    var fire_add := mods.get("enemy_fire_damage", 0.0)
+    if fire_add != 0.0:
+        enemy.stats.base_damage[Stats.DamageType.SOLAR] = enemy.stats.base_damage.get(Stats.DamageType.SOLAR, 0.0) + fire_add

--- a/scripts/zones/zone_generator.gd
+++ b/scripts/zones/zone_generator.gd
@@ -1,0 +1,60 @@
+class_name ZoneGenerator
+extends Resource
+
+# Builds a simple flat zone populated with enemies using one or more Zone Shards.
+# The returned PackedScene can be instanced and the player warped to it.
+
+const GeneratedZone = preload("res://scripts/zones/generated_zone.gd")
+
+@export var enemy_pack_scene: PackedScene
+@export var boss_scene: PackedScene
+@export var base_pack_count: int = 5
+@export var plane_size: float = 20.0
+
+func generate_zone(shards: Array[ZoneShard]) -> PackedScene:
+    var mods := _collect_modifiers(shards)
+    var root := GeneratedZone.new()
+    root.mods = mods
+
+    var plane := MeshInstance3D.new()
+    var mesh := PlaneMesh.new()
+    mesh.size = Vector2(plane_size, plane_size)
+    plane.mesh = mesh
+    root.add_child(plane)
+
+    var rng := RandomNumberGenerator.new()
+    rng.randomize()
+    var pack_count := int(base_pack_count * mods.get("spawn_mult", 1.0))
+    for i in range(pack_count):
+        if enemy_pack_scene:
+            var pack = enemy_pack_scene.instantiate()
+            var x = rng.randf_range(-plane_size * 0.5, plane_size * 0.5)
+            var z = rng.randf_range(-plane_size * 0.5, plane_size * 0.5)
+            pack.position = Vector3(x, 0, z)
+            root.add_child(pack)
+
+    if boss_scene:
+        var boss = boss_scene.instantiate()
+        boss.position = Vector3.ZERO
+        root.add_child(boss)
+
+    var packed := PackedScene.new()
+    packed.pack(root)
+    return packed
+
+func _collect_modifiers(shards: Array[ZoneShard]) -> Dictionary:
+    var mods := {"spawn_mult": 1.0, "enemy_hp_inc": 0.0, "enemy_fire_damage": 0.0}
+    for shard in shards:
+        if not shard:
+            continue
+        for aff in shard.affixes:
+            for key in aff.stat_bonuses.keys():
+                var v = aff.stat_bonuses[key]
+                match key:
+                    "enemy_spawn_inc":
+                        mods.spawn_mult *= 1.0 + v / 100.0
+                    "enemy_hp_inc":
+                        mods.enemy_hp_inc += v
+                    "enemy_fire_damage":
+                        mods.enemy_fire_damage += v
+    return mods


### PR DESCRIPTION
## Summary
- add `ZoneShard` item type and affix resources
- generate simple zones from shards via `ZoneGenerator`
- provide UI slot and inventory hooks for launching zones

## Testing
- `godot --headless --check` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: unable to locate package)*
- `curl` download of Godot binary *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6892af6e88a4832d860e3da0090f9723