### PR TITLE
Add passive skill tree framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,30 @@ Example: `resources/items/zone_shard.tres` shows a shard configured with these a
 
 ### Generating a Zone
 Attach `scripts/ui/zone_shard_slot.gd` to a `Control` that contains an `InventorySlot` for the shard and a `Button` to trigger the run. Export `zone_generator` to a `ZoneGenerator` resource (`scripts/zones/zone_generator.gd`) and set its `enemy_pack_scene` and `boss_scene` in the editor. When the button is pressed the control emits `zone_generated(PackedScene)`; instance this scene and warp the player to begin the encounter.
+
+## Passive Skill Tree
+The project now includes a framework for allocating passive skill nodes.
+Attach `scripts/passives/passive_tree.gd` to a `Control` that contains all of
+your passive nodes and set the following exports:
+
+- **player_path** – NodePath to the player so node effects can modify their
+  `Stats`.
+- **nodes_parent_path** – Optional path to the node container. If empty the
+  tree looks for `PassiveNode` children directly under itself.
+
+Create nodes by instancing Controls with one of the provided scripts:
+
+- `AttributeNode` – grants flat main stats. Set `stat` and `amount`.
+- `ModifierNode` – applies an `Affix` resource for standard stat bonuses.
+- `MasteryNode` – applies an `Affix` with powerful flags.
+- `WarpNode` – special node that links to other warp nodes.
+
+For each node use the exported `connections` array to link it to its neighbors.
+Warp nodes expose an additional `warp_connections` array. Set `is_root` on the
+starting node; it begins allocated. When the scene runs the tree automatically
+creates `Line2D` connections between nodes. Warp links are drawn in blue.
+
+Add passive points with `add_points()` and click nodes to allocate them.
+Nodes only become available if at least one connected node leading back to the
+root has already been allocated. Allocated nodes immediately apply their effects
+to the player's stats.

--- a/scripts/passives/attribute_node.gd
+++ b/scripts/passives/attribute_node.gd
@@ -1,0 +1,18 @@
+class_name AttributeNode
+extends PassiveNode
+
+@export var stat: Stats.MainStat = Stats.MainStat.BODY
+@export var amount: int = 1
+
+var _affix: Affix = null
+
+func apply_effect(player) -> void:
+    if player and player.stats:
+        _affix = Affix.new()
+        _affix.main_stat_bonuses[stat] = amount
+        player.stats.apply_affix(_affix)
+
+func remove_effect(player) -> void:
+    if player and player.stats and _affix:
+        player.stats.remove_affix(_affix)
+        _affix = null

--- a/scripts/passives/mastery_node.gd
+++ b/scripts/passives/mastery_node.gd
@@ -1,0 +1,15 @@
+class_name MasteryNode
+extends PassiveNode
+
+@export var affix: Affix
+var _instance: Affix = null
+
+func apply_effect(player) -> void:
+    if player and player.stats and affix:
+        _instance = affix.duplicate()
+        player.stats.apply_affix(_instance)
+
+func remove_effect(player) -> void:
+    if player and player.stats and _instance:
+        player.stats.remove_affix(_instance)
+        _instance = null

--- a/scripts/passives/modifier_node.gd
+++ b/scripts/passives/modifier_node.gd
@@ -1,0 +1,15 @@
+class_name ModifierNode
+extends PassiveNode
+
+@export var affix: Affix
+var _instance: Affix = null
+
+func apply_effect(player) -> void:
+    if player and player.stats and affix:
+        _instance = affix.duplicate()
+        player.stats.apply_affix(_instance)
+
+func remove_effect(player) -> void:
+    if player and player.stats and _instance:
+        player.stats.remove_affix(_instance)
+        _instance = null

--- a/scripts/passives/passive_node.gd
+++ b/scripts/passives/passive_node.gd
@@ -1,0 +1,37 @@
+class_name PassiveNode
+extends TextureButton
+
+@export var connections: Array[NodePath] = []
+@export var is_root: bool = false
+@export var cost: int = 1
+
+var tree: PassiveTree = null
+var allocated: bool = false
+
+func _ready() -> void:
+    connect("pressed", Callable(self, "_on_pressed"))
+
+func _on_pressed() -> void:
+    if tree:
+        tree.request_allocate(self)
+
+func get_connected_nodes() -> Array:
+    var result: Array = []
+    for p in connections:
+        var n = get_node_or_null(p)
+        if n:
+            result.append(n)
+    return result
+
+func get_draw_connections() -> Array:
+    # Returns dictionaries {"target": PassiveNode, "color": Color}
+    var arr: Array = []
+    for n in get_connected_nodes():
+        arr.append({"target": n, "color": Color.WHITE})
+    return arr
+
+func apply_effect(_player) -> void:
+    pass
+
+func remove_effect(_player) -> void:
+    pass

--- a/scripts/passives/passive_tree.gd
+++ b/scripts/passives/passive_tree.gd
@@ -1,0 +1,83 @@
+class_name PassiveTree
+extends Control
+
+@export var player_path: NodePath
+@export var nodes_parent_path: NodePath
+
+var _player
+var _nodes: Array[PassiveNode] = []
+var _lines_layer: Node2D
+var available_points: int = 0
+var root_node: PassiveNode
+
+func _ready() -> void:
+    if player_path != NodePath():
+        _player = get_node_or_null(player_path)
+    var parent: Node = self
+    if nodes_parent_path != NodePath():
+        parent = get_node(nodes_parent_path)
+    for child in parent.get_children():
+        if child is PassiveNode:
+            var node: PassiveNode = child
+            node.tree = self
+            _nodes.append(node)
+            if node.is_root:
+                root_node = node
+                node.allocated = true
+                node.apply_effect(_player)
+    _lines_layer = Node2D.new()
+    add_child(_lines_layer)
+    _lines_layer.z_index = -1
+    generate_lines()
+
+func add_points(count: int) -> void:
+    available_points += count
+
+func request_allocate(node: PassiveNode) -> void:
+    if can_allocate(node):
+        available_points -= node.cost
+        node.allocated = true
+        node.apply_effect(_player)
+        generate_lines()
+
+func can_allocate(node: PassiveNode) -> bool:
+    if node.allocated:
+        return false
+    if available_points < node.cost:
+        return false
+    if node.is_root:
+        return true
+    var connected = _get_connected_allocated()
+    for n in node.get_connected_nodes():
+        if n in connected:
+            return true
+    return false
+
+func _get_connected_allocated() -> Array:
+    if not root_node:
+        return []
+    var visited: Array = []
+    var queue: Array = [root_node]
+    while queue.size() > 0:
+        var current: PassiveNode = queue.pop_front()
+        if current in visited:
+            continue
+        visited.append(current)
+        for n in current.get_connected_nodes():
+            if n.allocated:
+                queue.append(n)
+    return visited
+
+func generate_lines() -> void:
+    for c in _lines_layer.get_children():
+        c.queue_free()
+    for node in _nodes:
+        for conn in node.get_draw_connections():
+            var target: PassiveNode = conn["target"]
+            if node.get_instance_id() < target.get_instance_id():
+                var line := Line2D.new()
+                line.default_color = conn["color"]
+                line.width = 2
+                line.add_point(node.position)
+                line.add_point(target.position)
+                _lines_layer.add_child(line)

--- a/scripts/passives/warp_node.gd
+++ b/scripts/passives/warp_node.gd
@@ -1,0 +1,21 @@
+class_name WarpNode
+extends PassiveNode
+
+@export var warp_connections: Array[NodePath] = []
+
+func get_connected_nodes() -> Array:
+    var result: Array = super.get_connected_nodes()
+    if allocated:
+        for p in warp_connections:
+            var n = get_node_or_null(p)
+            if n and n.allocated:
+                result.append(n)
+    return result
+
+func get_draw_connections() -> Array:
+    var arr: Array = super.get_draw_connections()
+    for p in warp_connections:
+        var n = get_node_or_null(p)
+        if n:
+            arr.append({"target": n, "color": Color.CORNFLOWER_BLUE})
+    return arr


### PR DESCRIPTION
## Summary
- introduce PassiveTree that manages passive nodes, point spending, and connection validation
- add PassiveNode base along with Attribute, Modifier, Mastery, and Warp variants
- document skill tree setup and node usage

## Testing
- `godot --headless --check` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_6893f2628a4c832d8c9dcb260bbbd5b6