### PR TITLE
Add basic NPC interaction system

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,23 +203,44 @@ instance is spawned for successful rolls.
 3. The player scene automatically belongs to the **"players"** group so enemies
    will find it without additional setup.
 
-## Enemy Hover Health Bar
-When the mouse cursor rests over an enemy a small UI at the top of the screen
-shows that enemy's full health. The enemy is also outlined with a thin red
-shader so it is clear which foe is targeted.
+## Hover Target Display
+When the mouse cursor rests over an enemy or friendly NPC a small UI at the top
+of the screen shows that target's name and health. Enemies are outlined with a
+thin red shader while NPCs use a green outline.
 
 1. Instance your custom `Healthbar.tscn` somewhere in the UI and attach
-   `scripts/ui/enemy_target_display.gd` to a parent `Control`.
-2. On the `EnemyTargetDisplay` node set:
+   `scripts/ui/enemy_target_display.gd` (class `TargetDisplay`) to a parent
+   `Control`.
+2. On the `TargetDisplay` node set:
    - **healthbar_path** – NodePath to the `Healthbar` instance.
    - Optional **name_label_path** and **level_label_path** to `Label` nodes if
      you want the script to fill them automatically.
-3. On the Player scene assign **target_display_path** to this
-   `EnemyTargetDisplay` node.
-4. For each enemy set `enemy_name` and `enemy_level` in `enemy.gd`. The script
-   will call `set_enemy_info(name, level)` on your `Healthbar` if it exists and
-   automatically applies the red outline while hovered.
+3. On the Player scene assign **target_display_path** to this `TargetDisplay`
+   node.
+4. For each enemy or NPC set `enemy_name` and `enemy_level` on their scripts so
+   the display can show them.
 
+## NPCs
+NPCs are non-combat characters the player can interact with. Clicking an NPC
+within range pauses the game, centers the camera on both characters and opens a
+dialogue box offering **Talk**, **Trade** or **Quit** options. Trade currently
+acts the same as Quit.
+
+### Creating an NPC Scene
+1. Add a `CharacterBody3D` and attach `scripts/npc.gd`.
+2. Add a `MeshInstance3D` and `CollisionShape3D` much like
+   `scenes/enemy.tscn`.
+3. Edit the exported properties:
+   - **enemy_name/level** – values shown in the hover UI.
+   - **dialogue_lines** – array of strings for the Talk option.
+   - **can_trade** – hide the Trade button if false.
+   - **interaction_range** – how close the player must be to talk.
+4. NPCs automatically join the `npc` group and use a green hover outline.
+
+To enable conversations add a `Control` with `scripts/ui/dialogue_box.gd` to a
+`CanvasLayer` and set the Player's `dialogue_ui_path` to that node. If left
+empty the Player will automatically create a `DialogueBox` under a sibling
+`CanvasLayer` at runtime.
 
 ## Zone Shards and Level Generation
 Zone Shards are consumable items that open a temporary zone. They reuse the existing affix framework so shards can roll modifiers that influence the generated level.

--- a/project.godot
+++ b/project.godot
@@ -79,6 +79,11 @@ toggle_skills_inv={
 ]
 }
 
+interact={
+"deadzone": 0.5,
+"events": [{"button_index": 1, "type": "mouse_button"}, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)]
+}
+
 [run]
 
 main_scene="res://scenes/Main.tscn"

--- a/scripts/npc.gd
+++ b/scripts/npc.gd
@@ -1,0 +1,44 @@
+extends CharacterBody3D
+## Simple non-combat character that the player can interact with.
+##
+## NPCs share targeting behaviour with enemies so the hover UI and outline
+## shader work the same way.  When clicked within `interaction_range` the
+## conversation UI is opened and the game is paused.
+##
+## To create an NPC in a scene:
+## 1. Add a `CharacterBody3D` and attach this script.
+## 2. Give it a `MeshInstance3D` and `CollisionShape3D` like `scenes/enemy.tscn`.
+## 3. Optionally tweak the exported properties below in the inspector.
+##
+## Dialogue lines can be edited directly in the inspector. Each entry in
+## `dialogue_lines` is displayed sequentially when the player chooses "Talk".
+
+@export var enemy_name: String = "Villager" ## Display name used by the target UI.
+@export var enemy_level: int = 1 ## Arbitrary level shown beside the name.
+@export var interaction_range: float = 3.0 ## Player must be this close to talk.
+@export var dialogue_lines: Array[String] = ["Hello there!"]
+@export var can_trade: bool = true ## When false the Trade option is hidden.
+
+# Minimal health fields so the existing target display can show a bar.
+@export var max_health: float = 1.0
+var current_health: float
+
+var _mesh: MeshInstance3D
+var _hover_outline_material: ShaderMaterial
+
+const HOVER_OUTLINE_SHADER := preload("res://resources/enemy_hover_outline.gdshader")
+
+func _ready() -> void:
+    current_health = max_health
+    add_to_group("npc")
+    _mesh = get_node_or_null("MeshInstance3D")
+    if _mesh:
+        _hover_outline_material = ShaderMaterial.new()
+        _hover_outline_material.shader = HOVER_OUTLINE_SHADER
+        _hover_outline_material.set_shader_parameter("outline_color", Color.GREEN)
+
+func set_hovered(hovered: bool) -> void:
+    ## Toggle the green outline when the mouse hovers this NPC.
+    if not _mesh:
+        return
+    _mesh.material_overlay = _hover_outline_material if hovered else null

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -11,6 +11,7 @@ extends CharacterBody3D
 
 # UI control that displays the hovered enemy's health bar.
 @export var target_display_path: NodePath
+@export var dialogue_ui_path: NodePath ## NodePath to the DialogueBox control.
 
 @export var healthbar_node_path: NodePath
 
@@ -42,8 +43,9 @@ var _camera_default_pos: Vector3
 var _inventory_open := false
 var _skills_open := false
 var _healthbar: Healthbar
-var _target_display: EnemyTargetDisplay
-var _hovered_enemy: Node
+ var _target_display: TargetDisplay
+ var _dialogue_ui: DialogueBox
+ var _hovered_target: Node
 var _current_move_multiplier: float = 1.0
 var buff_manager: BuffManager
 var reserved_mana: float = 0.0
@@ -104,23 +106,30 @@ func _ready() -> void:
 		_camera = get_node(inventory_camera_path)
 		if _camera:
 			_camera_default_pos = _camera.position
-	if healthbar_node_path != NodePath():
-		_healthbar = get_node(healthbar_node_path)
-		max_health = int(stats.get_max_health())
-		health = max_health
-		max_mana = stats.get_max_mana()
-		mana = max_mana
-		max_energy_shield = stats.get_max_energy_shield()
-		energy_shield = max_energy_shield
-		if _healthbar:
-			_healthbar.set_health(health, max_health)
-			_healthbar.set_mana(mana, max_mana)
-		if skills_ui_path != NodePath():
-				_skills_ui = get_node(skills_ui_path)
-				_skills_ui.bind_player(self)
+        if healthbar_node_path != NodePath():
+                  _healthbar = get_node(healthbar_node_path)
+                  max_health = int(stats.get_max_health())
+                  health = max_health
+                  max_mana = stats.get_max_mana()
+                  mana = max_mana
+                  max_energy_shield = stats.get_max_energy_shield()
+                  energy_shield = max_energy_shield
+                  if _healthbar:
+                          _healthbar.set_health(health, max_health)
+                          _healthbar.set_mana(mana, max_mana)
+                  if skills_ui_path != NodePath():
+                                  _skills_ui = get_node(skills_ui_path)
+                                  _skills_ui.bind_player(self)
 
-		if target_display_path != NodePath():
-				_target_display = get_node_or_null(target_display_path)
+        if target_display_path != NodePath():
+                        _target_display = get_node_or_null(target_display_path)
+        if dialogue_ui_path != NodePath():
+                        _dialogue_ui = get_node_or_null(dialogue_ui_path)
+        if not _dialogue_ui:
+                        var canvas_layer := get_node_or_null("../CanvasLayer")
+                        if canvas_layer:
+                                _dialogue_ui = DialogueBox.new()
+                                canvas_layer.add_child(_dialogue_ui)
 
 		add_to_group("player")
 
@@ -139,11 +148,12 @@ func _get_click_direction() -> Vector3:
 	return (target - global_transform.origin).normalized()
 
 func _physics_process(delta: float) -> void:
-		_process_inventory_input()
-		_process_attack(delta)
-		_process_movement(delta)
-		_process_regen(delta)
-		_update_enemy_hover()
+        _process_inventory_input()
+        _process_attack(delta)
+        _process_movement(delta)
+        _process_regen(delta)
+        _update_target_hover()
+        _process_npc_interact()
 
 func _process_movement(delta: float) -> void:
 	var input_dir = Vector3.ZERO
@@ -300,40 +310,51 @@ func _process_regen(delta: float) -> void:
 func die():
 		queue_free()
 
-func _update_enemy_hover() -> void:
-	"""Cast a ray from the camera to the mouse and update the target display."""
-	if not _target_display:
-		return
-	var camera := get_viewport().get_camera_3d()
-	if camera == null:
-		_target_display.update_enemy(null)
-		return
-	var mouse_pos := get_viewport().get_mouse_position()
-	var origin := camera.project_ray_origin(mouse_pos)
-	var dir := camera.project_ray_normal(mouse_pos)
-	var query := PhysicsRayQueryParameters3D.create(origin, origin + dir * 1000)
-	var result := get_world_3d().direct_space_state.intersect_ray(query)
-	var enemy: Node = null
-	if result and result.collider and result.collider.is_in_group("enemy"):
-		enemy = result.collider
-	elif result:
-		# If the ray hit something else, check a small sphere around the point
-		# of impact so near misses still select the enemy.
-		var sphere := SphereShape3D.new()
-		sphere.radius = 1.0
-		var shape_query := PhysicsShapeQueryParameters3D.new()
-		shape_query.shape = sphere
-		shape_query.transform = Transform3D(Basis(), result.position)
-		var hits := get_world_3d().direct_space_state.intersect_shape(shape_query)
-		for h in hits:
-			var c = h.collider
-			if c.is_in_group("enemy"):
-				enemy = c
-				break
-	if enemy != _hovered_enemy:
-		if _hovered_enemy and _hovered_enemy.has_method("set_hovered"):
-			_hovered_enemy.set_hovered(false)
-		_hovered_enemy = enemy
-		if _hovered_enemy and _hovered_enemy.has_method("set_hovered"):
-			_hovered_enemy.set_hovered(true)
-	_target_display.update_enemy(enemy)
+func _update_target_hover() -> void:
+        """Cast a ray from the camera to the mouse and update the target display."""
+        if not _target_display:
+                return
+        var camera := get_viewport().get_camera_3d()
+        if camera == null:
+                _target_display.update_target(null)
+                return
+        var mouse_pos := get_viewport().get_mouse_position()
+        var origin := camera.project_ray_origin(mouse_pos)
+        var dir := camera.project_ray_normal(mouse_pos)
+        var query := PhysicsRayQueryParameters3D.create(origin, origin + dir * 1000)
+        var result := get_world_3d().direct_space_state.intersect_ray(query)
+        var target: Node = null
+        if result and result.collider and (result.collider.is_in_group("enemy") or result.collider.is_in_group("npc")):
+                target = result.collider
+        elif result:
+                # If the ray hit something else, check a small sphere around the point
+                # of impact so near misses still select the target.
+                var sphere := SphereShape3D.new()
+                sphere.radius = 1.0
+                var shape_query := PhysicsShapeQueryParameters3D.new()
+                shape_query.shape = sphere
+                shape_query.transform = Transform3D(Basis(), result.position)
+                var hits := get_world_3d().direct_space_state.intersect_shape(shape_query)
+                for h in hits:
+                        var c = h.collider
+                        if c.is_in_group("enemy") or c.is_in_group("npc"):
+                                target = c
+                                break
+        if target != _hovered_target:
+                if _hovered_target and _hovered_target.has_method("set_hovered"):
+                        _hovered_target.set_hovered(false)
+                _hovered_target = target
+                if _hovered_target and _hovered_target.has_method("set_hovered"):
+                        _hovered_target.set_hovered(true)
+        _target_display.update_target(target)
+
+func _process_npc_interact() -> void:
+        ## Handle left-click interactions with friendly NPCs.
+        if not _hovered_target or not _hovered_target.is_in_group("npc"):
+                return
+        if not Input.is_action_just_pressed("interact"):
+                return
+        if global_transform.origin.distance_to(_hovered_target.global_transform.origin) > _hovered_target.interaction_range:
+                return
+        if _dialogue_ui and _camera:
+                _dialogue_ui.start_conversation(_hovered_target, self, _camera)

--- a/scripts/ui/dialogue_box.gd
+++ b/scripts/ui/dialogue_box.gd
@@ -1,0 +1,125 @@
+extends Control
+class_name DialogueBox
+## Simple textbox used for NPC conversations.
+##
+## The node builds its UI elements in `_ready` so no additional scene is
+## required.  Set `pause_mode` to `PROCESS` so it remains interactive while the
+## rest of the game is paused.
+##
+## Call `start_conversation(npc, player, camera)` to begin talking.  The camera
+## is temporarily repositioned to show both characters and restored when the
+## conversation ends.
+
+var _npc: Node
+var _player: Node3D
+var _camera: Camera3D
+var _camera_transform: Transform3D
+var _line_index: int = 0
+
+var _label: Label
+var _talk_button: Button
+var _trade_button: Button
+var _quit_button: Button
+var _next_button: Button
+
+func _ready() -> void:
+    pause_mode = Node.PAUSE_MODE_PROCESS
+    visible = false
+
+    var panel := Panel.new()
+    panel.anchor_right = 1.0
+    panel.anchor_bottom = 1.0
+    panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    add_child(panel)
+
+    _label = Label.new()
+    _label.autowrap_mode = TextServer.AUTOWRAP_WORD
+    _label.anchor_right = 1.0
+    _label.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    panel.add_child(_label)
+
+    var buttons := HBoxContainer.new()
+    buttons.anchor_top = 1.0
+    buttons.anchor_right = 1.0
+    buttons.offset_bottom = -10
+    buttons.offset_right = -10
+    buttons.offset_left = 10
+    buttons.offset_top = -40
+    buttons.grow_vertical = Control.GROW_DIRECTION_END
+    panel.add_child(buttons)
+
+    _talk_button = Button.new()
+    _talk_button.text = "Talk"
+    _talk_button.pressed.connect(_on_talk_pressed)
+    buttons.add_child(_talk_button)
+
+    _trade_button = Button.new()
+    _trade_button.text = "Trade"
+    _trade_button.pressed.connect(_end_conversation)
+    buttons.add_child(_trade_button)
+
+    _quit_button = Button.new()
+    _quit_button.text = "Quit"
+    _quit_button.pressed.connect(_end_conversation)
+    buttons.add_child(_quit_button)
+
+    _next_button = Button.new()
+    _next_button.text = "Next"
+    _next_button.pressed.connect(_show_next_line)
+    _next_button.visible = false
+    buttons.add_child(_next_button)
+
+func start_conversation(npc: Node, player: Node3D, camera: Camera3D) -> void:
+    ## Opens the dialogue box and pauses the game.
+    _npc = npc
+    _player = player
+    _camera = camera
+    _camera_transform = camera.global_transform
+    _line_index = 0
+    _show_options()
+    get_tree().paused = true
+    _reposition_camera()
+    visible = true
+
+func _reposition_camera() -> void:
+    if not _camera or not _npc or not _player:
+        return
+    var mid := (_player.global_transform.origin + _npc.global_transform.origin) * 0.5
+    var offset := (_camera_transform.origin - mid).normalized() * 6.0
+    _camera.global_transform.origin = mid + offset + Vector3.UP * 2.0
+    _camera.look_at(mid, Vector3.UP)
+
+func _show_options() -> void:
+    _label.text = _npc.dialogue_lines[0] if _npc.dialogue_lines.size() > 0 else ""
+    _talk_button.visible = true
+    _trade_button.visible = _npc.can_trade
+    _quit_button.visible = true
+    _next_button.visible = false
+
+func _on_talk_pressed() -> void:
+    _line_index = 0
+    _show_next_line()
+
+func _show_next_line() -> void:
+    if _npc.dialogue_lines.is_empty():
+        _show_options()
+        return
+    if _line_index < _npc.dialogue_lines.size():
+        _label.text = _npc.dialogue_lines[_line_index]
+        _line_index += 1
+        _talk_button.visible = false
+        _trade_button.visible = false
+        _quit_button.visible = false
+        _next_button.visible = true
+    else:
+        _show_options()
+
+func _end_conversation() -> void:
+    visible = false
+    get_tree().paused = false
+    if _camera:
+        _camera.global_transform = _camera_transform
+    _npc = null
+    _player = null
+    _camera = null

--- a/scripts/ui/enemy_target_display.gd
+++ b/scripts/ui/enemy_target_display.gd
@@ -1,10 +1,11 @@
 extends Control
-class_name EnemyTargetDisplay
-## Displays information about the currently hovered enemy.
+class_name TargetDisplay
+## Displays information about the currently hovered target.
 ##
-## The node expects a child `Healthbar` node (provided by you as a `.tscn`)
-## and optional `Label` nodes for the enemy's name and level.  All nodes are
-## referenced by exported `NodePath`s so they can be wired up in the editor.
+## Works for both hostile enemies and friendly NPCs.  The node expects a child
+## `Healthbar` node (provided by you as a `.tscn`) and optional `Label` nodes for
+## the name and level.  All nodes are referenced by exported `NodePath`s so they
+## can be wired up in the editor.
 
 @export var healthbar_path: NodePath
 @export var name_label_path: NodePath
@@ -24,31 +25,31 @@ func _ready() -> void:
 		_name_label = get_node_or_null(name_label_path)
 	if level_label_path != NodePath():
 		_level_label = get_node_or_null(level_label_path)
-	# Hide by default until an enemy is hovered.
-	visible = false
+        # Hide by default until something is hovered.
+        visible = false
 
-func update_enemy(enemy: Node) -> void:
-	## Call this every frame with the enemy under the mouse cursor.
-	## Pass `null` when no enemy is hovered to hide the display.
-	if enemy != _target:
-		_set_new_target(enemy)
-	elif _target:
-		_update_health()
+func update_target(target: Node) -> void:
+        ## Call this every frame with the Node under the mouse cursor.
+        ## Pass `null` when nothing is hovered to hide the display.
+        if target != _target:
+                _set_new_target(target)
+        elif _target:
+                _update_health()
 
-func _set_new_target(enemy: Node) -> void:
-	# Disconnect previous target if needed and assign the new one.
-	if _target and _target.has_signal("died") and _target.is_connected("died", Callable(self, "_on_target_died")):
-		_target.disconnect("died", Callable(self, "_on_target_died"))
-	_target = enemy
-	if _target:
-		# Forward name and level to any connected labels or the healthbar scene.
-		_update_labels()
-		_update_health()
-		if _target.has_signal("died"):
-			_target.connect("died", Callable(self, "_on_target_died"))
-		visible = true
-	else:
-		visible = false
+func _set_new_target(target: Node) -> void:
+        # Disconnect previous target if needed and assign the new one.
+        if _target and _target.has_signal("died") and _target.is_connected("died", Callable(self, "_on_target_died")):
+                _target.disconnect("died", Callable(self, "_on_target_died"))
+        _target = target
+        if _target:
+                # Forward name and level to any connected labels or the healthbar scene.
+                _update_labels()
+                _update_health()
+                if _target.has_signal("died"):
+                        _target.connect("died", Callable(self, "_on_target_died"))
+                visible = true
+        else:
+                visible = false
 
 func _update_health() -> void:
 	if _healthbar and _target and _healthbar.has_method("set_health"):


### PR DESCRIPTION
## Summary
- Add `npc.gd` for friendly characters with configurable dialogue and trade options
- Introduce programmatic `DialogueBox` UI and auto-spawn it when missing so scenes stay unchanged
- Generalize hover target display and update player controller to interact with NPCs via new `interact` action

## Testing
- `godot --headless --path . --check` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_6897862846a8832da1158f938759f306