### PR TITLE
feat: stack overlapping item tags and style by item type

### DIFF
--- a/scripts/items/item.gd
+++ b/scripts/items/item.gd
@@ -13,6 +13,7 @@ const MAX_AFFIXES := 6
 @export var description: String = ""
 @export var icon: Texture2D
 @export var max_stack: int = 1
+@export var item_type: String = ""
 
 # Name of the equipment slot this item fits in. Leave empty for non-equipable
 # items such as consumables.  Example values: "weapon", "armor", "ring".

--- a/scripts/items/item_pickup.gd
+++ b/scripts/items/item_pickup.gd
@@ -3,6 +3,7 @@ extends Area3D
 
 @export var item: Item
 @export var amount: int = 1
+@export var item_tag_layer_path: NodePath = NodePath("/root/WorldRoot/ItemTagLayer")
 
 var _player: Node
 var _tag: ItemTag
@@ -15,18 +16,13 @@ func _ready() -> void:
 	connect("mouse_exited", _on_mouse_exited)
 	connect("input_event", _on_input_event)
 
-	var layer = get_tree().get_root().get_node_or_null("WorldRoot/ItemTagLayer")
+        var layer: ItemTagLayer = get_tree().get_root().get_node_or_null(item_tag_layer_path)
 
-	_tag = ItemTag.new()
-	_tag.text = item.item_name
-	var tip := "%s\n%s" % [item.item_name, item.description]
-	var aff_text := item.get_affix_text()
-	if aff_text != "":
-		tip += "\n" + aff_text
-	_tag.tooltip_text = tip
-	_tag.target = self
-	layer.add_child(_tag)
-	_tag.connect("pressed", Callable(self, "_collect"))
+        _tag = ItemTag.new()
+        _tag.target = self
+        _tag.set_item(item)
+        layer.add_child(_tag)
+        _tag.connect("pressed", Callable(self, "_collect"))
 
 
 func _on_body_entered(body: Node) -> void:

--- a/scripts/items/item_tag.gd
+++ b/scripts/items/item_tag.gd
@@ -4,13 +4,29 @@ class_name ItemTag
 var target: Node3D
 @export var vertical_offset: float = 1.5
 var _camera: Camera3D
+var item: Item
 
 func _ready() -> void:
 	_camera = get_viewport().get_camera_3d()
 	focus_mode = FOCUS_NONE
 	size_flags_horizontal = Control.SIZE_SHRINK_CENTER
 	size_flags_vertical = Control.SIZE_SHRINK_CENTER
-	clip_text = false
+        clip_text = false
+
+func set_item(it: Item) -> void:
+        item = it
+        text = it.item_name
+        var tip := "%s\n%s" % [it.item_name, it.description]
+        var aff_text := it.get_affix_text()
+        if aff_text != "":
+                tip += "\n" + aff_text
+        tooltip_text = tip
+        _apply_style()
+
+func _apply_style() -> void:
+        var layer := get_parent()
+        if layer and layer.has_method("apply_style"):
+                layer.apply_style(self)
 
 func _process(delta: float) -> void:
 	if not target or not is_instance_valid(target):
@@ -22,7 +38,10 @@ func _process(delta: float) -> void:
 			return
 	var pos := target.global_transform.origin
 	pos.y += vertical_offset
-	var screen_point: Vector2 = _camera.unproject_position(pos)
-	position = screen_point - size * 0.5
-	#visible = _camera.is_position_behind(pos) == false
-	visible = true
+        var screen_point: Vector2 = _camera.unproject_position(pos)
+        position = screen_point - size * 0.5
+        #visible = _camera.is_position_behind(pos) == false
+        visible = true
+        var layer := get_parent()
+        if layer and layer.has_method("request_stack_update"):
+                layer.request_stack_update()

--- a/scripts/items/item_tag_layer.gd
+++ b/scripts/items/item_tag_layer.gd
@@ -1,0 +1,45 @@
+extends CanvasLayer
+class_name ItemTagLayer
+
+@export var vertical_spacing: float = 4.0
+@export var tag_styles: Array[ItemTagStyle] = []
+
+var _needs_stack := false
+
+func request_stack_update() -> void:
+    if _needs_stack:
+        return
+    _needs_stack = true
+    call_deferred("_update_stacks")
+
+func _update_stacks() -> void:
+    _needs_stack = false
+    var groups: Dictionary = {}
+    for child in get_children():
+        if not child is ItemTag:
+            continue
+        var key := Vector2i(child.position.round())
+        if not groups.has(key):
+            groups[key] = []
+        groups[key].append(child)
+    for tags in groups.values():
+        if tags.size() <= 1:
+            continue
+        for i in range(tags.size()):
+            var tag: ItemTag = tags[i]
+            tag.position.y -= i * (tag.size.y + vertical_spacing)
+
+func apply_style(tag: ItemTag) -> void:
+    if not tag.item:
+        return
+    var style := _get_style(tag.item.item_type)
+    if style:
+        tag.add_theme_color_override("font_color", style.color)
+        if style.icon:
+            tag.icon = style.icon
+
+func _get_style(item_type: String) -> ItemTagStyle:
+    for style in tag_styles:
+        if style.item_type == item_type:
+            return style
+    return null

--- a/scripts/items/item_tag_style.gd
+++ b/scripts/items/item_tag_style.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name ItemTagStyle
+
+@export var item_type: String = ""
+@export var color: Color = Color.WHITE
+@export var icon: Texture2D


### PR DESCRIPTION
## Summary
- allow each Item to declare an `item_type`
- expose ItemTagLayer to arrange overlapping tags into vertical stacks and apply styles
- make ItemPickup use NodePath for the tag layer and use ItemTag.set_item for style

## Testing
- `gdlint scripts/items/item_tag_layer.gd scripts/items/item_tag_style.gd scripts/items/item_tag.gd scripts/items/item_pickup.gd scripts/items/item.gd` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b5781d64832dbc89d5e5f8b481b5