### PR TITLE
feat: integrate player animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@ The `project.godot` file is configured to run `scenes/Main.tscn` by default and 
 - **Right Mouse Button** – Rotate toward the clicked position and perform a melee attack. The attack area is displayed briefly as a red cylinder in front of the player.
 - **Q** – Activate the secondary skill (e.g., the Haste aura).
 
+## Player Animations
+The `player.gd` script now drives an `AnimationTree` for directional movement and attack animations.
+
+### Setting up the AnimationTree
+1. In `scenes/Player.tscn` add your character model with an `AnimationPlayer` containing at minimum: `idle`, `run_left`, `run_right`, `run_up`, `run_down`, `slash` and `cast` animations.
+2. Add an `AnimationTree` node and assign the `AnimationPlayer` to it. Set **Tree Root** to `StateMachine` and enable the tree.
+3. Inside the state machine create a state named **move** using an `AnimationNodeBlendSpace2D`. Place the run animations at
+   - `(0, 0)` – idle
+   - `(-1, 0)` – run_left
+   - `(1, 0)` – run_right
+   - `(0, -1)` – run_up
+   - `(0, 1)` – run_down
+4. Create states named **slash** and **cast**. Wrap each animation in an `AnimationNodeTimeScale` so their speed can be changed at runtime.
+5. Add transitions from **move** to **slash** and **cast**, and back to **move** when the animations finish.
+6. In the Player node's inspector set **animation_tree_path** to the new `AnimationTree`.
+
+`player.gd` updates the blend position at `parameters/move/blend_position` using the player's movement relative to the cursor. Attack states are entered by name via the skill's `animation_name` property and their `TimeScale/scale` parameter is adjusted using the character's attack speed.
+
+### Slash timing
+Skill resources now expose `animation_name`, `attack_time` and `cancel_time`. For a slash attack set:
+```
+duration     – length of the slash animation at 1× speed
+attack_time  – when the hit should occur
+cancel_time  – when the remaining animation can be cancelled
+animation_name = "slash"
+```
+The player script accelerates or slows the animation based on `attack_speed` and triggers the skill at `attack_time`.
+
 ## Camera
 The main camera now tracks the player character. It preserves the original
 offset configured in the scene and lerps toward the player each frame. When the

--- a/scripts/skills/skill.gd
+++ b/scripts/skills/skill.gd
@@ -11,6 +11,9 @@ extends Resource
 @export var base_damage_low: float = 0.0
 @export var base_damage_high: float = 0.0
 @export var tags: Array[String] = []
+@export var animation_name: StringName = &""
+@export var attack_time: float = 0.0 ## Seconds into the animation when the attack is applied.
+@export var cancel_time: float = 0.0 ## Seconds into the animation when the remainder can be cancelled.
 
 func perform(user):
 	pass

--- a/scripts/stats.gd
+++ b/scripts/stats.gd
@@ -45,6 +45,7 @@ var base_damage: Dictionary = {
 	DamageType.UNHOLY: 0.0,
 }
 var base_move_speed: float = 5.0
+var base_attack_speed: float = 1.0
 var base_defense: float = 0.0
 var base_max_health: float = 0.0
 var base_max_mana: float = 0.0
@@ -203,8 +204,11 @@ func compute_damage(extra_base: Dictionary, tags: Array[String] = []) -> Diction
 
 
 func get_move_speed() -> float:
-	return _compute_stat(base_move_speed, "move_speed")
+    return _compute_stat(base_move_speed, "move_speed")
 
+
+func get_attack_speed() -> float:
+    return _compute_stat(base_attack_speed, "attack_speed")
 
 func get_defense() -> float:
 	return _compute_stat(base_defense, "defense")


### PR DESCRIPTION
## Summary
- add attack speed stat and animation controls to Player
- support animation-driven attack timing with cancel windows
- document AnimationTree setup and skill timings

## Testing
- `godot3 --headless --check` *(fails: config_version 5 incompatible with engine 3)*

------
https://chatgpt.com/codex/tasks/task_e_6898df4de900832da4f60593645ee94a