### PR TITLE
feat: display equipped item meshes on player

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,39 @@ already has a container for items.
    runtime. If you prefer to manage it manually, add a `CanvasLayer` with that
    name to your main scene and optionally customize its draw order.
 
+### Equipping 3D Models
+Items can display 3D meshes on the player when equipped.  Each `Item` resource
+exposes two new properties:
+
+- **model** – `PackedScene` containing the mesh or mesh collection.
+- **equip_transform** – orientation and offset applied to the model when
+  attached.
+
+#### Importing Weapon or Offhand Models
+1. In Blender, orient the weapon so it points forward relative to the player's
+   hand and export it as a `.glb`.
+2. Drag the file into Godot. The importer will generate a `*.glb` scene.
+3. Create an `Item` resource and assign the imported scene to its `model`
+   property.
+4. Set `equip_slot` to `weapon` or `offhand`.
+5. Adjust `equip_transform` by rotating or translating the preview so the model
+   lines up with the hand.  The values are applied relative to the hand bone at
+   runtime (`mixamorig_RightHand` for weapons and `mixamorig_LeftHand` for
+   offhands).
+
+#### Importing Armor Pieces
+1. Author the armour in Blender using the same skeleton as the player and
+   export to `.glb` ensuring bone names are preserved.
+2. Import the file into Godot and save the resulting scene.
+3. Create an `Item` resource with `equip_slot` set to `armor` and assign the
+   scene to `model`.
+4. Optionally tweak `equip_transform` if the mesh needs an offset.
+
+When the player equips an item the scene is instanced and attached to the
+appropriate bone or the root skeleton.  All `MeshInstance3D` nodes inside the
+scene are re-targeted to the player's skeleton so animations drive the new
+mesh.
+
 ### Item Tag Collision Handling
 Item tags spawned in the world will now avoid overlapping each other. Every tag
 projects its 3D position into screen space and checks for rectangle intersections

--- a/scripts/items/equipment_visual_manager.gd
+++ b/scripts/items/equipment_visual_manager.gd
@@ -1,0 +1,93 @@
+extends Node3D
+class_name EquipmentVisualManager
+
+##
+# Handles instancing and attachment of 3D models for equipped items.
+#
+# This node listens to an [EquipmentManager] and spawns the `Item.model`
+# scenes when items are equipped.  Models are attached to the player's
+# skeleton so they follow animations.  Weapon and offhand items are attached
+# to specific hand bones via [BoneAttachment3D] nodes while armour meshes are
+# skinned to the skeleton directly.
+#
+# Usage:
+#   1. Create this node and assign the `skeleton` and `equipment` properties.
+#   2. The manager will automatically respond to `slot_changed` signals.
+#   3. Ensure `Item.equip_transform` is configured so the model aligns
+#      correctly with the player's hand or body.
+##
+
+@export var skeleton: Skeleton3D ## Player skeleton used for attachments.
+@export var equipment: EquipmentManager ## Source of equip/unequip events.
+
+## Mapping of equipment slot names to the skeleton bone used for attachment.
+## Slots not listed here will be added directly under the skeleton.
+const SLOT_BONES := {
+    "weapon": "mixamorig_RightHand",
+    "offhand": "mixamorig_LeftHand",
+}
+
+# Instanced models currently attached, indexed by slot.
+var _models: Dictionary = {}
+
+# BoneAttachment3D nodes created for hand slots.
+var _attachments: Dictionary = {}
+
+func _ready() -> void:
+    if equipment:
+        equipment.connect("slot_changed", _on_slot_changed)
+    # Pre-create attachment points for mapped slots.
+    if skeleton:
+        for slot in SLOT_BONES.keys():
+            var bone_name: String = SLOT_BONES[slot]
+            var attach := BoneAttachment3D.new()
+            attach.bone_name = bone_name
+            skeleton.add_child(attach)
+            _attachments[slot] = attach
+
+func _on_slot_changed(slot: String, item: Item) -> void:
+    ## Remove existing model for this slot and attach the new one if any.
+    _clear_slot(slot)
+    if not item or item.model == null:
+        return
+    var instance: Node3D = item.model.instantiate()
+    instance.transform = item.equip_transform
+    if slot == "armor":
+        _equip_armor(instance)
+    elif slot in SLOT_BONES:
+        _attachments[slot].add_child(instance)
+        _models[slot] = instance
+    else:
+        skeleton.add_child(instance)
+        _models[slot] = instance
+
+func _clear_slot(slot: String) -> void:
+    var model = _models.get(slot, null)
+    if model:
+        if model is Array:
+            for m in model:
+                if is_instance_valid(m):
+                    m.queue_free()
+        elif is_instance_valid(model):
+            model.queue_free()
+        _models.erase(slot)
+
+func _equip_armor(root: Node3D) -> void:
+    ## Attach an armour model by retargeting all MeshInstance3D nodes to the
+    ## player's skeleton.  The original scene is freed after extraction.
+    var meshes: Array = []
+    _collect_meshes(root, meshes)
+    for m in meshes:
+        var global_xform: Transform3D = m.global_transform
+        skeleton.add_child(m)
+        m.global_transform = global_xform
+        m.skeleton = m.get_path_to(skeleton)
+    root.queue_free()
+    _models["armor"] = meshes
+
+func _collect_meshes(node: Node, out: Array) -> void:
+    ## Recursively gather MeshInstance3D nodes from `node` into `out`.
+    if node is MeshInstance3D:
+        out.append(node)
+    for c in node.get_children():
+        _collect_meshes(c, out)

--- a/scripts/items/item.gd
+++ b/scripts/items/item.gd
@@ -25,6 +25,18 @@ const MAX_AFFIXES := 6
 # Affixes currently attached to this item.
 @export var affixes: Array[Affix] = []
 
+# Optional 3D model representing the item when equipped.  The scene should
+# contain a `MeshInstance3D` (for armor it may contain multiple meshes) and is
+# instanced and attached to the player when this item is equipped. Leave null
+# for items that do not have a visual representation.
+@export var model: PackedScene
+
+# Transform applied to `model` when attached to the player.  This allows the
+# orientation and offset to be tweaked in the inspector so the item aligns
+# correctly with the hand or body.  The transform is relative to the attach
+# point (e.g. the character's hand bone).
+@export var equip_transform: Transform3D = Transform3D.IDENTITY
+
 
 func reroll_affixes() -> void:
 		# Clears existing affixes and rolls new ones from `affix_pool`.

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -11,6 +11,10 @@ extends CharacterBody3D
 @export var skills_ui_path: NodePath
 @export var animation_tree_path: NodePath
 
+# Skeleton containing the player's bones.  Equipment models are attached to
+# this skeleton so they follow animations.
+@export var skeleton_path: NodePath = NodePath("Armature/Skeleton3D")
+
 # UI control that displays the hovered enemy's health bar.
 @export var target_display_path: NodePath
 @export var dialogue_ui_path: NodePath ## NodePath to the DialogueBox control.
@@ -84,6 +88,7 @@ var max_mana:float = 50.0
 var stats: Stats
 var equipment: EquipmentManager
 var rune_manager: RuneManager
+var _equip_visuals: EquipmentVisualManager
 
 func _ready() -> void:
 	stats = Stats.new()
@@ -105,10 +110,17 @@ func _ready() -> void:
 	stats.base_mana_regen = base_mana_regen
 	stats.base_attack_speed = base_attack_speed
 
-	equipment = EquipmentManager.new()
-	equipment.stats = stats
-	equipment.set_slots(["weapon", "armor"])
-	add_child(equipment)
+        equipment = EquipmentManager.new()
+        equipment.stats = stats
+        equipment.set_slots(["weapon", "offhand", "armor"])
+        add_child(equipment)
+
+        # Visual manager displays meshes for equipped items.
+        var skeleton: Skeleton3D = get_node_or_null(skeleton_path)
+        _equip_visuals = EquipmentVisualManager.new()
+        _equip_visuals.skeleton = skeleton
+        _equip_visuals.equipment = equipment
+        add_child(_equip_visuals)
 
 	rune_manager = RuneManager.new()
 	add_child(rune_manager)


### PR DESCRIPTION
## Summary
- add `model` and `equip_transform` properties to items for attaching 3D scenes
- draw equipped weapons, offhands and armor using a new EquipmentVisualManager
- document how to import and orient meshes for equipment

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a6e5f25a4832db9761a2312052ac6