### PR TITLE
feat: add reusable drop and affix groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ code.
 3. Save the resource inside `resources/affixes/` and assign it to an item's
    `affix_pool` array. Call `reroll_affixes()` to roll new affixes.
 
+### Affix Groups
+Multiple items can now share a common pool of affixes. Create an
+**AffixGroup** resource (`scripts/items/affix_group.gd`) and populate its
+`affixes` array with `AffixDefinition` resources. Items expose a new exported
+`affix_groups` array; all definitions from these groups are merged with the
+item's own `affix_pool` when `reroll_affixes()` is called.
+
+This allows creating broad categories such as *boots* or *rings* without
+manually listing the same affixes on every item. See
+`resources/affix_groups/boots.tres` and `resources/items/test_boots.tres` for an
+example.
+
 Several sample definitions are included covering additive and increased bonuses
 for Body, Mind, Soul, Luck, movement speed, maximum health/mana and their
 regeneration.  Unique examples like `life_steal.tres` and `body_to_mind.tres`
@@ -275,15 +287,21 @@ enemy is:
 
 Enemies can drop loot using the `drop_table` export on `enemy.gd`. Each entry in
 the array is a dictionary like `{"item": Item, "chance": 0.5, "amount": 1}`.
-When the enemy dies every entry is rolled and a matching `item_drop.tscn`
-instance is spawned for successful rolls.
+Enemies may also reference any number of reusable **DropTable** resources via
+the new `drop_tables` array. When the enemy dies all entries from the local
+`drop_table` and assigned `DropTable` resources are rolled and a matching
+`item_drop.tscn` instance is spawned for successful rolls.
+Create shared tables as resources using `scripts/drop_table.gd` and populate
+their `entries` array with the same dictionaries used in `drop_table`.
+An example can be found at `resources/drop_tables/basic.tres`.
 
 ### Updating Existing Scenes
 1. Open your enemy scene in Godot and ensure `enemy.gd` is attached to the root
    `CharacterBody3D`.
 2. Set the exported properties such as movement speeds, detection and attack
    ranges.  Configure `base_damage_low/high`, `base_damage_types` and the enemy
-   `tier`, then assign the `drop_table` with your item resources.
+   `tier`, then assign the `drop_table` with your item resources. Optional
+   global tables can be added through the `drop_tables` array.
 3. The player scene automatically belongs to the **"players"** group so enemies
    will find it without additional setup.
 

--- a/resources/affix_groups/boots.tres
+++ b/resources/affix_groups/boots.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="AffixGroup" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/items/affix_group.gd" id="1"]
+[ext_resource type="Resource" path="res://resources/affixes/move_speed_inc.tres" id="2"]
+[ext_resource type="Resource" path="res://resources/affixes/evasion_inc.tres" id="3"]
+[ext_resource type="Resource" path="res://resources/affixes/max_health_add.tres" id="4"]
+
+[resource]
+script = ExtResource("1")
+affixes = [ExtResource("2"), ExtResource("3"), ExtResource("4")]

--- a/resources/drop_tables/basic.tres
+++ b/resources/drop_tables/basic.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" script_class="DropTable" load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/drop_table.gd" id="1"]
+[ext_resource type="Resource" path="res://resources/items/test_item.tres" id="2"]
+[ext_resource type="Resource" path="res://resources/items/chaos_orb.tres" id="3"]
+
+[resource]
+script = ExtResource("1")
+entries = [{
+"item": ExtResource("2"),
+"chance": 0.5,
+"amount": 1
+}, {
+"item": ExtResource("3"),
+"chance": 0.8,
+"amount": 5
+}]

--- a/resources/items/test_boots.tres
+++ b/resources/items/test_boots.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" script_class="Item" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/items/item.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/items/affix.gd" id="2"]
+[ext_resource type="Texture2D" path="res://images/items/test_item.png" id="3"]
+[ext_resource type="Resource" path="res://resources/affix_groups/boots.tres" id="4"]
+
+[resource]
+script = ExtResource("1")
+item_name = "Test Boots"
+description = "Example item using a shared affix group"
+icon = ExtResource("3")
+max_stack = 1
+equip_slot = "feet"
+affix_pool = []
+affix_groups = [ExtResource("4")]
+affixes = Array[ExtResource("2")]([])

--- a/scripts/drop_table.gd
+++ b/scripts/drop_table.gd
@@ -1,0 +1,7 @@
+class_name DropTable
+extends Resource
+
+# Global loot table usable by multiple enemies.
+# Each entry is a dictionary: {"item": Item, "chance": float, "amount": int}
+# When an enemy dies, all assigned DropTables are merged and rolled.
+@export var entries: Array[Dictionary] = []

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -38,6 +38,10 @@ const TIER_SIZE_MULT := {Tier.PACK: 1.0, Tier.LEADER: 1.5, Tier.BOSS: 2.5}
 ## {"item": Item, "chance": 0.5, "amount": 1}
 @export var drop_table: Array = []
 
+# Optional list of reusable DropTable resources. All entries from these tables
+# are merged with `drop_table` when generating loot.
+@export var drop_tables: Array[DropTable] = []
+
 var current_health: float
 var energy_shield: float = 0.0
 var max_energy_shield: float = 0.0
@@ -197,18 +201,19 @@ func die() -> void:
 	queue_free()
 
 func _drop_loot() -> void:
-	var drop_scene := preload("res://scenes/item_drop.tscn")
-	for entry in drop_table:
-		if randf() <= float(entry.get("chance", 1.0)):
-			var drop := drop_scene.instantiate()
-			var area := drop.get_node_or_null("Area3D")
-			print(entry)
-			if area and entry.has("item"):
-				#print("that being said, entry item is ", entry["item"].item_name)
-				area.item = entry["item"]
-			if entry.has("amount"):
-				area.amount = entry["amount"]
-			print("dropping item ", area.item)
-			
-			get_parent().add_child(drop)
-			drop.global_transform.origin = global_transform.origin
+        var drop_scene := preload("res://scenes/item_drop.tscn")
+        var combined: Array = []
+        combined.append_array(drop_table)
+        for table in drop_tables:
+                if table:
+                        combined.append_array(table.entries)
+        for entry in combined:
+                if randf() <= float(entry.get("chance", 1.0)):
+                        var drop := drop_scene.instantiate()
+                        var area := drop.get_node_or_null("Area3D")
+                        if area and entry.has("item"):
+                                area.item = entry["item"]
+                        if area and entry.has("amount"):
+                                area.amount = entry["amount"]
+                        get_parent().add_child(drop)
+                        drop.global_transform.origin = global_transform.origin

--- a/scripts/items/affix_group.gd
+++ b/scripts/items/affix_group.gd
@@ -1,0 +1,5 @@
+class_name AffixGroup
+extends Resource
+
+# Bundle of AffixDefinitions that can be reused across multiple items.
+@export var affixes: Array[AffixDefinition] = []

--- a/scripts/items/item.gd
+++ b/scripts/items/item.gd
@@ -22,6 +22,9 @@ const MAX_AFFIXES := 6
 # Pool of definitions this item may roll affixes from when crafted.
 @export var affix_pool: Array[AffixDefinition] = []
 
+# Optional groups of affixes that can be shared across multiple items.
+@export var affix_groups: Array[AffixGroup] = []
+
 # Affixes currently attached to this item.
 @export var affixes: Array[Affix] = []
 
@@ -41,14 +44,18 @@ const MAX_AFFIXES := 6
 
 
 func reroll_affixes() -> void:
-		# Clears existing affixes and rolls new ones from `affix_pool`.
-	affixes.clear()
-	if affix_pool.is_empty():
-		return
-	var pool := affix_pool.duplicate()
-	for i in range(MAX_AFFIXES):
-		if pool.is_empty():
-			break
+                # Clears existing affixes and rolls new ones from `affix_pool`.
+        affixes.clear()
+        var pool: Array[AffixDefinition] = []
+        pool.append_array(affix_pool)
+        for g in affix_groups:
+                if g:
+                        pool.append_array(g.affixes)
+        if pool.is_empty():
+                return
+        for i in range(MAX_AFFIXES):
+                if pool.is_empty():
+                        break
 		if i < 3 or randf() < 0.5:
 			var def: AffixDefinition = pool.pick_random()
 			pool.erase(def)


### PR DESCRIPTION
## Summary
- support reusable drop tables on enemies
- add affix groups to share available affixes across items
- document global drop tables and affix groups and provide examples

## Testing
- `godot --headless --check-only project.godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e09426c68832db728b14534e98b9b