### PR TITLE
feat: add attack animations to enemies

### DIFF
--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -8,6 +8,7 @@ extends CharacterBody3D
 @export var attack_range: float = 1.5
 @export var main_skill: Skill = preload("res://resources/skills/fireball.tres")
 @export var healthbar_node_path: NodePath
+@export var animation_tree_path: NodePath
 @export var base_armor: float = 0.0
 @export var base_evasion: float = 0.0
 @export var base_max_energy_shield: float = 0.0
@@ -53,12 +54,19 @@ var _player: Node3D
 var _wander_timer: float = 0.0
 var _current_dir: Vector3 = Vector3.ZERO
 var _attack_timer: float = 0.0
+var _attacking_timer: float = 0.0
+var _attack_progress: float = 0.0
+var _attack_execute_time: float = 0.0
+var _attack_cancel_time: float = 0.0
+var _attack_performed: bool = false
 var _mesh: MeshInstance3D
 var _original_material: Material
 var _hover_outline_material: ShaderMaterial
 var _healthbar: Healthbar
 var stats: Stats
 var buff_manager: BuffManager
+var _anim_tree: AnimationTree
+var _anim_state: AnimationNodeStateMachinePlayback
 
 const HOVER_OUTLINE_SHADER := preload("res://resources/enemy_hover_outline.gdshader")
 
@@ -81,15 +89,19 @@ func _ready() -> void:
 	current_health = max_health
 	max_energy_shield = stats.get_max_energy_shield()
 	energy_shield = max_energy_shield
-	buff_manager = BuffManager.new()
-	buff_manager.stats = stats
-	add_child(buff_manager)
-	_player = get_tree().get_root().find_child("Player", true, false)
-	_mesh = get_node_or_null("MeshInstance3D")
-	if _mesh:
-			_original_material = _mesh.material_override
-			_mesh.scale = Vector3(TIER_SIZE_MULT[tier], TIER_SIZE_MULT[tier], TIER_SIZE_MULT[tier])
-			# Create a material using the hover outline shader.  It will be
+        buff_manager = BuffManager.new()
+        buff_manager.stats = stats
+        add_child(buff_manager)
+        _player = get_tree().get_root().find_child("Player", true, false)
+        if animation_tree_path != NodePath():
+                _anim_tree = get_node_or_null(animation_tree_path)
+                if _anim_tree:
+                        _anim_state = _anim_tree.get("parameters/playback")
+        _mesh = get_node_or_null("MeshInstance3D")
+        if _mesh:
+                        _original_material = _mesh.material_override
+                        _mesh.scale = Vector3(TIER_SIZE_MULT[tier], TIER_SIZE_MULT[tier], TIER_SIZE_MULT[tier])
+                        # Create a material using the hover outline shader.  It will be
 			# assigned to `material_overlay` when the mouse hovers this enemy
 			# so the original surface materials remain visible.
 			_hover_outline_material = ShaderMaterial.new()
@@ -102,20 +114,44 @@ func _ready() -> void:
 					$Sprite3D.position.y += 2
 
 func _physics_process(delta: float) -> void:
-	_process_regen(delta)
-	_process_timers(delta)
-	var player_pos := _get_player_position()
-	if player_pos and global_transform.origin.distance_to(player_pos) <= attack_range and _attack_timer <= 0.0 and main_skill:
-		_attack_timer = main_skill.cooldown
-		main_skill.perform(self)
-	elif player_pos and global_transform.origin.distance_to(player_pos) <= detection_range:
-		_chase(player_pos, delta)
-	else:
-		_wander(delta)
+        _process_regen(delta)
+        var player_pos := _get_player_position()
+        _process_attack(delta, player_pos)
+        if player_pos and global_transform.origin.distance_to(player_pos) <= detection_range:
+                _chase(player_pos, delta)
+        else:
+                _wander(delta)
+        _update_animation()
 
-func _process_timers(delta: float) -> void:
-	if _attack_timer > 0.0:
-		_attack_timer -= delta
+func _process_attack(delta: float, player_pos: Vector3) -> void:
+        if _attack_timer > 0.0:
+                _attack_timer -= delta
+        if _attacking_timer > 0.0:
+                _attacking_timer -= delta
+                _attack_progress += delta
+                if not _attack_performed and _attack_progress >= _attack_execute_time:
+                        if main_skill:
+                                main_skill.perform(self)
+                        _attack_performed = true
+                if _attack_cancel_time > 0.0 and _attack_progress >= _attack_cancel_time:
+                        _attacking_timer = 0.0
+                if _attacking_timer <= 0.0 and _anim_state:
+                        _anim_state.travel("move")
+        elif player_pos and global_transform.origin.distance_to(player_pos) <= attack_range and _attack_timer <= 0.0 and main_skill:
+                var speed = stats.get_attack_speed()
+                _attack_timer = main_skill.cooldown / max(speed, 0.001)
+                _attacking_timer = main_skill.duration / max(speed, 0.001)
+                _attack_progress = 0.0
+                _attack_execute_time = main_skill.attack_time / max(speed, 0.001)
+                _attack_cancel_time = main_skill.cancel_time / max(speed, 0.001)
+                _attack_performed = false
+                if _anim_state and main_skill.animation_name != &"":
+                        _anim_tree.set("parameters/%s/TimeScale/scale" % str(main_skill.animation_name), speed)
+                        _anim_state.travel(String(main_skill.animation_name))
+                else:
+                        main_skill.perform(self)
+                        _attack_performed = true
+                        _attacking_timer = 0.0
 
 func _process_regen(delta: float) -> void:
 	max_energy_shield = stats.get_max_energy_shield()
@@ -126,22 +162,42 @@ func _process_regen(delta: float) -> void:
 			energy_shield = min(max_energy_shield, energy_shield + stats.get_energy_shield_regen() * delta)
 
 func _wander(delta: float) -> void:
-	_wander_timer -= delta
-	if _wander_timer <= 0.0:
-		_wander_timer = wander_change_interval
-		_current_dir = Vector3(randf() * 2.0 - 1.0, 0, randf() * 2.0 - 1.0).normalized()
-	if _current_dir != Vector3.ZERO:
-		var target_rot := Transform3D().looking_at(_current_dir, Vector3.UP).basis.get_euler().y
-		rotation.y = lerp_angle(rotation.y, target_rot, 5.0 * delta)
-	velocity = _current_dir * wander_speed
-	move_and_slide()
+        _wander_timer -= delta
+        if _wander_timer <= 0.0:
+                _wander_timer = wander_change_interval
+                _current_dir = Vector3(randf() * 2.0 - 1.0, 0, randf() * 2.0 - 1.0).normalized()
+        if _current_dir != Vector3.ZERO:
+                var target_rot := Transform3D().looking_at(_current_dir, Vector3.UP).basis.get_euler().y
+                rotation.y = lerp_angle(rotation.y, target_rot, 5.0 * delta)
+        if _attacking_timer > 0.0:
+                velocity = Vector3.ZERO
+        else:
+                velocity = _current_dir * wander_speed
+        move_and_slide()
 
 func _chase(player_pos: Vector3, delta: float) -> void:
-		var dir := (player_pos - global_transform.origin).normalized()
-		var target_rot := Transform3D().looking_at(dir, Vector3.UP).basis.get_euler().y
-		rotation.y = lerp_angle(rotation.y, target_rot, 5.0 * delta)
-		velocity = dir * move_speed
-		move_and_slide()
+                var dir := (player_pos - global_transform.origin).normalized()
+                var target_rot := Transform3D().looking_at(dir, Vector3.UP).basis.get_euler().y
+                rotation.y = lerp_angle(rotation.y, target_rot, 5.0 * delta)
+                if _attacking_timer > 0.0:
+                        velocity = Vector3.ZERO
+                else:
+                        velocity = dir * move_speed
+                move_and_slide()
+
+func _update_animation() -> void:
+        if not _anim_tree or not _anim_state:
+                return
+        if _attacking_timer > 0.0:
+                return
+        _anim_state.travel("move")
+        var world_vel = Vector3(velocity.x, 0, velocity.z)
+        var basis = global_transform.basis.orthonormalized()
+        var right = basis.x
+        var forward = -basis.z
+        var local_x = world_vel.dot(right)
+        var local_y = world_vel.dot(forward)
+        _anim_tree.set("parameters/move/blend_position", Vector2(local_x, local_y))
 
 func set_hovered(hovered: bool) -> void:
 		# Toggles the thin red outline when the mouse is over the enemy.


### PR DESCRIPTION
## Summary
- add animation tree hookup for enemies
- delay enemy skills until their attack animation reaches the execute time

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e58cceec8832d95f9a621f17c3500