### PR TITLE
Add crafting jewels and persistent enemy aggro

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,24 @@ Three sample items – `mystic_ring.tres`, `mystic_amulet.tres` and
 `mystic_boots.tres` – showcase how to create items that can roll any of these
 affixes.
 
-### Crafting with Chaos Orbs
-When a **Chaos Orb** is on the cursor, right‑clicking an item consumes one orb
-and rerolls all of that item's affixes. Affix tiers are rolled with weighted
-probabilities; lower tier numbers (better rolls) are rarer than higher tier
-numbers.
+### Crafting with Currency Items
+Placing a crafting currency on the cursor and right‑clicking an item attempts to
+modify that item's affixes. The following currencies are supported:
+
+* **Chaos Orb** – rerolls all affixes.
+* **Temper Jewel** – rerolls the tier of one random affix.
+* **Culling Jewel** – removes one random affix.
+* **Elevating Jewel** – adds a new random affix.
+* **Cleansing Jewel** – removes all affixes.
+
+These currencies are only consumed when the action succeeds; for example a
+Culling Jewel will not be spent on an item with no affixes.
+
+To create a jewel in Godot 4.4, make a new `.tres` Resource using
+`scripts/items/item.gd`, set `item_name` to the jewel's name, assign an icon and
+`max_stack`, then place the resource anywhere under `resources/items/`.
+Icons can be assigned like the existing `chaos_orb.tres` under
+`resources/items/currency/`.
 
 ### Displaying Affixes
 Hovering over an item tag in the world or over an inventory slot now shows the
@@ -271,7 +284,8 @@ item's affixes in its tooltip.
 ## Enemy Behavior
 Enemies now wander around randomly until the player gets close. When the player
 enters the `detection_range` exported on `enemy.gd`, the enemy will chase the
-player. If the player reaches `attack_range`, the enemy performs a short
+player and will continue to pursue until the player moves more than five times
+that distance away. If the player reaches `attack_range`, the enemy performs a short
 wind‑up before dealing damage. During the wind‑up the enemy's material turns
 red to telegraph the attack and then reverts back afterwards.
 

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -69,6 +69,7 @@ var stats: Stats
 var buff_manager: BuffManager
 var _anim_tree: AnimationTree
 var _anim_state: AnimationNodeStateMachinePlayback
+var _player_detected: bool = false
 
 const HOVER_OUTLINE_SHADER := preload("res://resources/enemy_hover_outline.gdshader")
 
@@ -117,14 +118,21 @@ func _ready() -> void:
 					$Sprite3D.position.y *= 3
 
 func _physics_process(delta: float) -> void:
-		_process_regen(delta)
-		var player_pos := _get_player_position()
-		_process_attack(delta, player_pos)
-		if player_pos and global_transform.origin.distance_to(player_pos) <= detection_range:
-				_chase(player_pos, delta)
-		else:
-				_wander(delta)
-		_update_animation()
+                _process_regen(delta)
+                var player_pos := _get_player_position()
+                _process_attack(delta, player_pos)
+                if player_pos:
+                                var dist := global_transform.origin.distance_to(player_pos)
+                                if _player_detected:
+                                                if dist > detection_range * 5.0:
+                                                                _player_detected = false
+                                elif dist <= detection_range:
+                                                _player_detected = true
+                if _player_detected and player_pos:
+                                _chase(player_pos, delta)
+                else:
+                                _wander(delta)
+                _update_animation()
 
 func _process_attack(delta: float, player_pos: Vector3) -> void:
 		if _attack_timer > 0.0:

--- a/scripts/items/item.gd
+++ b/scripts/items/item.gd
@@ -43,24 +43,69 @@ const MAX_AFFIXES := 6
 @export var equip_rotation_rads:Vector3 = Vector3.ZERO
 
 
-func reroll_affixes() -> void:
-				# Clears existing affixes and rolls new ones from `affix_pool`.
-		affixes.clear()
-		var pool: Array[AffixDefinition] = []
-		pool.append_array(affix_pool)
-		for g in affix_groups:
-				if g:
-						pool.append_array(g.affixes)
-		if pool.is_empty():
-				return
-		for i in range(MAX_AFFIXES):
-				if pool.is_empty():
-						break
-				if i < 3 or randf() < 0.5:
-					var def: AffixDefinition = pool.pick_random()
-					pool.erase(def)
-					var tier := _roll_weighted_tier(def.get_tier_count())
-					affixes.append(def.roll(tier))
+func reroll_affixes() -> bool:
+        # Clears existing affixes and rolls new ones from `affix_pool`.
+        affixes.clear()
+        var pool: Array[AffixDefinition] = _get_all_affix_definitions()
+        if pool.is_empty():
+                return false
+        for i in range(MAX_AFFIXES):
+                if pool.is_empty():
+                        break
+                if i < 3 or randf() < 0.5:
+                        var def: AffixDefinition = pool.pick_random()
+                        pool.erase(def)
+                        var tier := _roll_weighted_tier(def.get_tier_count())
+                        affixes.append(def.roll(tier))
+        return not affixes.is_empty()
+
+
+func temper_random_affix() -> bool:
+        # Rerolls the tier of a random existing affix.
+        if affixes.is_empty():
+                return false
+        var index := randi_range(0, affixes.size() - 1)
+        var current: Affix = affixes[index]
+        var def := _find_affix_definition(current.name)
+        if not def:
+                return false
+        var tier := _roll_weighted_tier(def.get_tier_count())
+        affixes[index] = def.roll(tier)
+        return true
+
+
+func remove_random_affix() -> bool:
+        # Removes one random affix from the item.
+        if affixes.is_empty():
+                return false
+        var index := randi_range(0, affixes.size() - 1)
+        affixes.remove_at(index)
+        return true
+
+
+func add_random_affix() -> bool:
+        # Adds a new random affix if capacity allows.
+        if affixes.size() >= MAX_AFFIXES:
+                return false
+        var pool: Array[AffixDefinition] = _get_all_affix_definitions()
+        for a in affixes:
+                for d in pool.duplicate():
+                        if d.name == a.name:
+                                pool.erase(d)
+        if pool.is_empty():
+                return false
+        var def: AffixDefinition = pool.pick_random()
+        var tier := _roll_weighted_tier(def.get_tier_count())
+        affixes.append(def.roll(tier))
+        return true
+
+
+func clear_affixes() -> bool:
+        # Removes all affixes from the item.
+        if affixes.is_empty():
+                return false
+        affixes.clear()
+        return true
 
 
 func _roll_weighted_tier(count: int) -> int:
@@ -82,6 +127,22 @@ func _roll_weighted_tier(count: int) -> int:
 func get_affix_text() -> String:
 	# Returns a multi-line string listing all affixes on the item.
 	var lines: Array[String] = []
-	for a in affixes:
-		lines.append(a.get_description())
-	return "\n".join(lines)
+        for a in affixes:
+                lines.append(a.get_description())
+        return "\n".join(lines)
+
+
+func _get_all_affix_definitions() -> Array[AffixDefinition]:
+        var pool: Array[AffixDefinition] = []
+        pool.append_array(affix_pool)
+        for g in affix_groups:
+                if g:
+                        pool.append_array(g.affixes)
+        return pool
+
+
+func _find_affix_definition(n: String) -> AffixDefinition:
+        for d in _get_all_affix_definitions():
+                if d.name == n:
+                        return d
+        return null

--- a/scripts/ui/inventory_ui.gd
+++ b/scripts/ui/inventory_ui.gd
@@ -178,26 +178,39 @@ func _on_slot_right_clicked(index: int) -> void:
 	if not _inventory:
 		return
 
-		# Consume one Chaos Orb and reroll the item's affixes.
-	var data = _inventory.get_slot(index)
-	var item: Item = data["item"]
-	if _cursor_item and _cursor_item.item_name == "Chaos Orb" and item:
-		# Consume one Chaos Orb and reroll the item's affixes.
-		item.reroll_affixes()
-		_cursor_amount -= 1
-		if _cursor_amount <= 0:
-			_cursor_item = null
-			_cursor_amount = 0
-		_inventory.clear_slot(index)
-		_inventory.place_item(index, item, data["amount"])
-		_update_cursor()
-		_update_slots()
-		return
-	if not _equipment:
-		return
-	if item and item.equip_slot != "":
-		_inventory.clear_slot(index)
-		var swapped = _equipment.equip(item)
+        var data = _inventory.get_slot(index)
+        var item: Item = data["item"]
+        if _cursor_item and item:
+                var success := false
+                match _cursor_item.item_name:
+                        "Chaos Orb":
+                                success = item.reroll_affixes()
+                        "Temper Jewel":
+                                success = item.temper_random_affix()
+                        "Culling Jewel":
+                                success = item.remove_random_affix()
+                        "Elevating Jewel":
+                                success = item.add_random_affix()
+                        "Cleansing Jewel":
+                                success = item.clear_affixes()
+                        _:
+                                pass
+                if _cursor_item.item_name in ["Chaos Orb", "Temper Jewel", "Culling Jewel", "Elevating Jewel", "Cleansing Jewel"]:
+                        if success:
+                                _cursor_amount -= 1
+                                if _cursor_amount <= 0:
+                                        _cursor_item = null
+                                        _cursor_amount = 0
+                                _inventory.clear_slot(index)
+                                _inventory.place_item(index, item, data["amount"])
+                                _update_slots()
+                        _update_cursor()
+                        return
+        if not _equipment:
+                return
+        if item and item.equip_slot != "":
+                _inventory.clear_slot(index)
+                var swapped = _equipment.equip(item)
 		if swapped:
 			var leftover = _inventory.place_item(index, swapped, 1)
 			if leftover:


### PR DESCRIPTION
## Summary
- Add Temper, Culling, Elevating and Cleansing jewels that manipulate item affixes
- Prevent currency consumption when crafting fails
- Enemies keep chasing players until they're 5× beyond detection range

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eda244858832da6cfb99c0f5043b4