### PR TITLE
Add skill hotbar icon UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ The player now uses mana to power abilities. Basic attacks consume mana and the
 player regenerates 1 mana per second up to a base maximum of 50. Affixes and
 items can modify maximum mana and regeneration rates.
 
+## Skill Hotbar UI
+`skill_icon.gd` displays icons for equipped skills and shows their cooldowns,
+active state and whether the player has enough mana.
+
+### Setup
+1. Add a `TextureButton` for each hotbar slot.
+2. Optionally add child nodes:
+   - `TextureProgressBar` for cooldown progress.
+   - `Control` (e.g. `ColorRect`) to highlight when the skill is active.
+   - `Control` for an overlay when mana is insufficient.
+3. Attach `scripts/ui/skill_icon.gd` to the button.
+4. Set **player_path**, **slot_index** and the overlay NodePaths in the inspector.
+5. Hovering the button displays the skill name and description.
+6. Fill out the new `description` field on each `Skill` resource to populate the tooltip.
+
+
 ## Skills and Tags
 Skills are `Resource` files that carry tags describing how they behave. Supported tags include `Melee`, `Spell`, `Projectile`, `AoE`, `Aura`, `Channel`, `Summon` and `Movement`. Affixes can grant flat or increased damage to specific tags such as `physical_damage_melee` or `holy_damage_spell`. Damage from equipped items is applied when a skill with matching tags is used, allowing weapons and armor to contribute to spell or melee damage independently.
 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -361,13 +361,31 @@ func _on_rune_skill_changed(index: int, skill: Skill) -> void:
 		secondary_skill = skill
 
 func get_skill_slot(index: int) -> Skill:
-	if rune_manager:
-		return rune_manager.get_skill(index)
-	return null
+        if rune_manager:
+                return rune_manager.get_skill(index)
+        return null
+
+func get_skill_cooldown_remaining(index: int) -> float:
+	match index:
+		0:
+			return max(_attack_timer, 0.0)
+		1:
+			return max(_secondary_cooldown, 0.0)
+		_:
+			return 0.0
+
+func is_skill_active(index: int) -> bool:
+	match index:
+		0:
+			return _attacking_timer > 0.0
+		1:
+			return false
+		_:
+			return false
 
 func set_skill_slot(_index: int, _skill: Skill) -> void:
-		# Skills are determined by rune combinations; manual assignment disabled.
-	pass
+                # Skills are determined by rune combinations; manual assignment disabled.
+        pass
 
 func add_item(item: Item, amount: int = 1) -> void:
 	if _inventory_open and _inventory_ui:

--- a/scripts/skills/skill.gd
+++ b/scripts/skills/skill.gd
@@ -2,6 +2,7 @@ class_name Skill
 extends Resource
 
 @export var name: String = ""
+@export_multiline var description: String = ""
 @export var icon: Texture2D
 @export var mana_cost: float = 0.0
 @export var cooldown: float = 0.0

--- a/scripts/ui/skill_icon.gd
+++ b/scripts/ui/skill_icon.gd
@@ -1,0 +1,47 @@
+class_name SkillIcon
+extends TextureButton
+
+# Displays a player's skill with cooldown, active state and mana cost feedback.
+# Designed to be attached to a TextureButton in the editor. Child nodes
+# referenced via the exported NodePaths are optional and allow custom visuals.
+
+@export var player_path: NodePath
+@export var slot_index: int = 0
+@export var cooldown_progress_path: NodePath
+@export var active_overlay_path: NodePath
+@export var mana_overlay_path: NodePath
+
+var _player
+var _cooldown_progress: Range
+var _active_overlay: CanvasItem
+var _mana_overlay: CanvasItem
+
+func _ready() -> void:
+	if player_path != NodePath():
+		_player = get_node(player_path)
+	if cooldown_progress_path != NodePath():
+		_cooldown_progress = get_node(cooldown_progress_path)
+	if active_overlay_path != NodePath():
+		_active_overlay = get_node(active_overlay_path)
+	if mana_overlay_path != NodePath():
+		_mana_overlay = get_node(mana_overlay_path)
+	set_process(true)
+
+func _process(_delta: float) -> void:
+	if not _player:
+		return
+	var skill: Skill = _player.get_skill_slot(slot_index)
+	texture_normal = skill.icon if skill else null
+	if skill:
+		tooltip_text = "%s\n%s" % [skill.name, skill.description]
+	else:
+		tooltip_text = ""
+	var cooldown = _player.get_skill_cooldown_remaining(slot_index)
+	if _cooldown_progress and skill:
+		var denom = max(skill.cooldown, 0.001)
+		_cooldown_progress.value = cooldown / denom * _cooldown_progress.max_value
+		_cooldown_progress.visible = cooldown > 0.0
+	if _active_overlay:
+		_active_overlay.visible = _player.is_skill_active(slot_index)
+	if _mana_overlay and skill:
+		_mana_overlay.visible = _player.mana < skill.mana_cost


### PR DESCRIPTION
## Summary
- add `SkillIcon` UI script to display skill cooldown, active status, and mana availability
- expose skill cooldown and active state on `player.gd`
- add description field to `Skill` resources and document skill hotbar setup

## Testing
- `godot --headless --check` *(fails: Resource file not found uid://dduutvhpgaapk)*

------
https://chatgpt.com/codex/tasks/task_e_689fa89b1938832dbca1a59e5635b111