### PR TITLE
feat: add spawn and enemy generation to tile levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ This repository contains a simple Godot 4 project configured for a modular actio
 
 The `project.godot` file is configured to run `scenes/Main.tscn` by default and defines input actions for movement and attacking.
 
+## Tile Level Generation
+`scripts/tile_levels/tile_level_generator.gd` can procedurally assemble rooms and tunnels using data from a `TileLevelSettings`
+resource. The generator:
+- constrains rooms to `level_size` so everything fits within a defined rectangle.
+- places a `PlayerSpawn` marker in the first room and, if a boss scene is provided, instantiates it in the farthest room.
+- spawns random enemies from `enemy_scenes` on interior (center) tiles using `enemy_density` to control how crowded areas
+  become.
+All spawned nodes are positioned using the resource's `tile_size` so they line up with the generated tiles.
+
 ## Creating Additional Scenes
 1. Open the project in Godot.
 2. Add 3D nodes (enemies, environment, etc.) to `scenes/Main.tscn` or create new scenes that can be instanced into Main.

--- a/scripts/tile_levels/tile_level_settings.gd
+++ b/scripts/tile_levels/tile_level_settings.gd
@@ -27,6 +27,24 @@ const TunnelSize := {
 # Optional fixed seed. Set to 0 to randomize.
 @export var seed: int = 0
 
+# --- Level bounds ----------------------------------------------------------
+# Maximum size of the generated level in tile coordinates. Rooms are
+# positioned so their rectangles fit within these dimensions. Any tiles or
+# corridors carved outside the bounds are discarded.
+@export var level_size: Vector2i = Vector2i(100, 100)
+
+# --- Enemy spawning --------------------------------------------------------
+# Collection of enemy scenes that may be instanced on valid floor tiles. One
+# is chosen at random for each spawn point.
+@export var enemy_scenes: Array[PackedScene] = []
+# Chance per valid center tile to spawn an enemy. Values near 0 produce sparse
+# encounters while 1.0 fills every available tile.
+@export_range(0.0, 1.0) var enemy_density: float = 0.0
+
+# Optional boss scene placed at the farthest room from the player spawn. If
+# left empty a simple Node3D marker named "BossSpawn" will be added instead.
+@export var boss_scene: PackedScene
+
 # Example usage in code:
 # var settings := load("res://path/to/your_settings.tres")
 # var level := TileLevelGenerator.new().generate(settings)


### PR DESCRIPTION
## Summary
- add level bounds, enemy scenes, density, and boss scene exports to level settings
- generate player and boss spawn points and random enemies on valid tiles
- document tile level generator usage and new properties in README

## Testing
- `godot --headless --check` *(fails: command not found)*
- `apt-get install -y godot` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a122138918832d8cea8bb319070e60