### PR TITLE
Align movement with camera and cull off‑screen enemies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All spawned nodes are positioned using the resource's `tile_size` so they line u
 3. Extend `player.gd` or create additional scripts for abilities, items, and other gameplay elements to keep things modular.
 
 ## Controls
-- **WASD** – Move the player.
+- **WASD** – Move the player relative to the camera's facing.
 - **Right Mouse Button** – Rotate toward the clicked position and perform a melee attack. The attack area is displayed briefly as a red cylinder in front of the player.
 - **Q** – Activate the secondary skill (e.g., the Haste aura).
 - **Dodge action** – Perform a directional dodge roll with a short invincibility window. Configure the input mapping in Project Settings.
@@ -71,6 +71,12 @@ The main camera now tracks the player character. It preserves the original
 offset configured in the scene and lerps toward the player each frame. When the
 inventory is open the camera shifts sideways by `inventory_camera_shift` so the
 UI does not obscure the action.
+
+## Camera-Oriented Movement
+WASD input is interpreted in the camera's local space. Rotating the camera
+changes which world direction counts as "forward" so the player always moves in
+relation to the current view. Dodge rolls also reuse the last camera-relative
+direction.
 
 ## Mana System
 The player now uses mana to power abilities. Basic attacks consume mana and the
@@ -393,6 +399,13 @@ thin red shader while NPCs use a green outline.
    node.
 4. For each enemy or NPC set `enemy_name` and `enemy_level` on their scripts so
    the display can show them.
+
+## Enemy Culling
+Enemies automatically pause their processing and hide their meshes when they
+leave the camera's view. The `OffscreenCuller` script
+(`scripts/offscreen_culler.gd`) uses `VisibleOnScreenNotifier3D` to reactivate
+them once they are visible again, allowing large numbers of enemies without
+slowing the editor or game.
 
 ## NPCs
 NPCs are non-combat characters the player can interact with. Clicking an NPC

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -36,6 +36,7 @@ enum Tier { PACK, LEADER, BOSS }
 const TIER_HEALTH_MULT := {Tier.PACK: 1.0, Tier.LEADER: 1.5, Tier.BOSS: 3.0}
 const TIER_DAMAGE_MULT := {Tier.PACK: 1.0, Tier.LEADER: 1.25, Tier.BOSS: 2.0}
 const TIER_SIZE_MULT := {Tier.PACK: 1.0, Tier.LEADER: 1.25, Tier.BOSS: 1.75}
+const OffscreenCuller = preload("res://scripts/offscreen_culler.gd")
 
 ## Drop table is an array of dictionaries like:
 ## {"item": Item, "chance": 0.5, "amount": 1}
@@ -108,14 +109,21 @@ func _ready() -> void:
 						# Create a material using the hover outline shader.  It will be
 			# assigned to `material_overlay` when the mouse hovers this enemy
 			# so the original surface materials remain visible.
-	_hover_outline_material = ShaderMaterial.new()
-	_hover_outline_material.shader = HOVER_OUTLINE_SHADER
-	if healthbar_node_path != NodePath():
-			_healthbar = get_node(healthbar_node_path)
-			if(_healthbar):
-				_healthbar.set_health(current_health, max_health)
-				if(tier == Tier.BOSS):
-					$Sprite3D.position.y *= 3
+        _hover_outline_material = ShaderMaterial.new()
+        _hover_outline_material.shader = HOVER_OUTLINE_SHADER
+        if healthbar_node_path != NodePath():
+                        _healthbar = get_node(healthbar_node_path)
+                        if(_healthbar):
+                                _healthbar.set_health(current_health, max_health)
+                                if(tier == Tier.BOSS):
+                                        $Sprite3D.position.y *= 3
+
+        # Instantiate a culler so enemies outside the camera view are paused
+        # and hidden, allowing thousands of enemies without impacting the editor.
+        var _culler := OffscreenCuller.new()
+        if _mesh:
+                _culler.visual_path = _mesh.get_path()
+        add_child(_culler)
 
 func _physics_process(delta: float) -> void:
 				_process_regen(delta)

--- a/scripts/offscreen_culler.gd
+++ b/scripts/offscreen_culler.gd
@@ -1,0 +1,46 @@
+extends VisibleOnScreenNotifier3D
+## Component that disables processing and rendering of a target node when it
+## leaves the camera's view.  Attach as a child of the object to monitor.  This
+## helps keep performance stable with large numbers of enemies.
+##
+## Godot 4.4 docs: https://docs.godotengine.org/en/latest/classes/class_visibleonscreennotifier3d.html
+class_name OffscreenCuller
+
+@export var target_path: NodePath = NodePath("..")
+## Optional node to hide when culled. If left empty the target itself is hidden.
+@export var visual_path: NodePath
+
+var _target: Node3D
+var _visual: Node3D
+
+func _ready() -> void:
+        _target = get_node_or_null(target_path)
+        if visual_path != NodePath():
+                _visual = get_node_or_null(visual_path)
+        if not _visual and _target:
+                _visual = _target
+        connect("screen_exited", Callable(self, "_on_screen_exited"))
+        connect("screen_entered", Callable(self, "_on_screen_entered"))
+
+func _on_screen_exited() -> void:
+        _set_active(false)
+
+func _on_screen_entered() -> void:
+        _set_active(true)
+
+func _set_active(active: bool) -> void:
+        # Toggle rendering.
+        if _visual:
+                _visual.visible = active
+        if not _target:
+                return
+        # Toggle processing on the target while leaving this culler running.
+        _target.set_process(active)
+        _target.set_physics_process(active)
+        for child in _target.get_children():
+                if child == self:
+                        continue
+                child.set_process(active)
+                child.set_physics_process(active)
+        if not active and _target is CharacterBody3D:
+                _target.velocity = Vector3.ZERO


### PR DESCRIPTION
## Summary
- Move and dodge relative to the active camera so controls feel consistent from any view angle
- Add OffscreenCuller utility and hook enemies to pause and hide when off screen
- Document camera-relative movement and enemy culling

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a1358b95d0832d8157f679a12fa327