### PR TITLE
Optimize ItemTag stacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,16 @@ Icons can be assigned like the existing `chaos_orb.tres` under
 Hovering over an item tag in the world or over an inventory slot now shows the
 item's affixes in its tooltip.
 
+### Optimized Item Tags
+Item nameplates used to adjust their positions every frame to avoid overlapping
+with neighbouring tags.  This approach became expensive with many dropped items
+because each tag checked every other tag on the screen.  The `ItemTagLayer`
+now groups tags by the world position of their items and assigns each a stack
+index.  Individual `ItemTag` nodes simply project their item into screen space
+and apply this fixed offset.  Stacks are recalculated only when tags are added
+or removed, dramatically reducing per‑frame work while still presenting a
+readable column of names like in classic ARPGs.
+
 ## Enemy Behavior
 Enemies now wander around randomly until the player gets close. When the player
 enters the `detection_range` exported on `enemy.gd`, the enemy will chase the

--- a/scripts/items/item_pickup.gd
+++ b/scripts/items/item_pickup.gd
@@ -7,53 +7,55 @@ extends Area3D
 
 var _player: Node
 var _tag: ItemTag
-
+var _layer: ItemTagLayer
 
 func _ready() -> void:
-	connect("body_entered", _on_body_entered)
-	connect("body_exited", _on_body_exited)
-	connect("mouse_entered", _on_mouse_entered)
-	connect("mouse_exited", _on_mouse_exited)
-	connect("input_event", _on_input_event)
+        connect("body_entered", _on_body_entered)
+        connect("body_exited", _on_body_exited)
+        connect("mouse_entered", _on_mouse_entered)
+        connect("mouse_exited", _on_mouse_exited)
+        connect("input_event", _on_input_event)
 
-	var layer: ItemTagLayer = get_tree().get_root().get_node_or_null(item_tag_layer_path)
+        _layer = get_tree().get_root().get_node_or_null(item_tag_layer_path)
 
-	_tag = ItemTag.new()
-	_tag.target = self
-	_tag.set_item(item)
-	layer.add_child(_tag)
-	_tag.connect("pressed", Callable(self, "_collect"))
-
+        _tag = ItemTag.new()
+        _tag.target = self
+        _tag.set_item(item)
+        if _layer:
+                _layer.add_tag(_tag)
+        else:
+                add_child(_tag) # fallback so tag still appears during testing
+        _tag.connect("pressed", Callable(self, "_collect"))
 
 func _on_body_entered(body: Node) -> void:
-	if body.has_method("add_item"):
-		_player = body
-
+        if body.has_method("add_item"):
+                _player = body
 
 func _on_body_exited(body: Node) -> void:
-	if body == _player:
-		_player = null
-
+        if body == _player:
+                _player = null
 
 func _on_mouse_entered() -> void:
-	pass
-
+        pass
 
 func _on_mouse_exited() -> void:
-	pass
-
+        pass
 
 func _on_input_event(
-	_camera: Node, event: InputEvent, _position: Vector3, _normal: Vector3, _shape_idx: int
+        _camera: Node, event: InputEvent, _position: Vector3, _normal: Vector3, _shape_idx: int
 ) -> void:
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		_collect()
-
+        if (
+                event is InputEventMouseButton
+                and event.pressed
+                and event.button_index == MOUSE_BUTTON_LEFT
+        ):
+                _collect()
 
 func _collect() -> void:
-	if _player and item:
-		_player.add_item(item, amount)
-		if _tag:
-			_tag.queue_free()
-		get_parent().queue_free()
-		
+        if _player and item:
+                _player.add_item(item, amount)
+                if _layer and _tag:
+                        _layer.remove_tag(_tag)
+                elif _tag:
+                        _tag.queue_free()
+                get_parent().queue_free()

--- a/scripts/items/item_tag_layer.gd
+++ b/scripts/items/item_tag_layer.gd
@@ -1,45 +1,76 @@
-extends CanvasLayer
 class_name ItemTagLayer
+extends CanvasLayer
+
+## Central manager for item nameplates displayed above dropped items.
+##
+## Tags no longer attempt to resolve overlaps against their siblings every
+## frame.  Instead the layer groups tags by the world position of their target
+## `ItemPickup` and assigns each tag a stack index.  This index is used by
+## `ItemTag` to apply a fixed vertical offset in screen space, effectively
+## creating a column of labels for items that occupy the same location.  Because
+## items are static the stack only needs to be recalculated when tags are added
+## or removed.
 
 @export var vertical_spacing: float = 4.0
 @export var tag_styles: Array[ItemTagStyle] = []
 
-var _needs_stack := false
+# Dictionary mapping a world-position key to an array of tags at that location.
+var _groups: Dictionary = {}
 
-func request_stack_update() -> void:
-	if _needs_stack:
-		return
-	_needs_stack = true
-	call_deferred("_update_stacks")
+## Register a tag with the layer.  The tag will become a child of the layer and
+## automatically receive a stack index.
+func add_tag(tag: ItemTag) -> void:
+        add_child(tag)
+        _register_tag(tag)
 
-func _update_stacks() -> void:
-	_needs_stack = false
-	var groups: Dictionary = {}
-	for child in get_children():
-		if not child is ItemTag:
-			continue
-		var key := Vector2i(child.position.round())
-		if not groups.has(key):
-			groups[key] = []
-		groups[key].append(child)
-	for tags in groups.values():
-		if tags.size() <= 1:
-			continue
-		for i in range(tags.size()):
-			var tag: ItemTag = tags[i]
-			tag.position.y -= i * (tag.size.y + vertical_spacing)
+## Remove a tag from the layer and update the remaining stack.
+func remove_tag(tag: ItemTag) -> void:
+        _unregister_tag(tag)
+        tag.queue_free()
 
+## Apply per-item styling such as colour and optional icon.
 func apply_style(tag: ItemTag) -> void:
-	if not tag.item:
-		return
-	var style := _get_style(tag.item.item_type)
-	if style:
-		tag.add_theme_color_override("font_color", style.color)
-		if style.icon:
-			tag.icon = style.icon
+        if not tag.item:
+                return
+        var style := _get_style(tag.item.item_type)
+        if style:
+                tag.add_theme_color_override("font_color", style.color)
+                if style.icon:
+                        tag.icon = style.icon
+
+# --- Internal helpers -------------------------------------------------------
 
 func _get_style(item_type: String) -> ItemTagStyle:
-	for style in tag_styles:
-		if style.item_type == item_type:
-			return style
-	return null
+        for style in tag_styles:
+                if style.item_type == item_type:
+                        return style
+        return null
+
+func _register_tag(tag: ItemTag) -> void:
+        var key := _key_from_target(tag.target)
+        if not _groups.has(key):
+                _groups[key] = []
+        _groups[key].append(tag)
+        _restack_group(key)
+
+func _unregister_tag(tag: ItemTag) -> void:
+        var key := _key_from_target(tag.target)
+        if not _groups.has(key):
+                return
+        _groups[key].erase(tag)
+        if _groups[key].is_empty():
+                _groups.erase(key)
+        else:
+                _restack_group(key)
+
+func _restack_group(key: Vector3i) -> void:
+        var tags: Array = _groups.get(key, [])
+        for i in range(tags.size()):
+                (tags[i] as ItemTag).set_stack_index(i, vertical_spacing)
+
+## Generate a dictionary key based on an item's world position.  Rounding keeps
+## nearby floating point values grouped together.
+func _key_from_target(target: Node3D) -> Vector3i:
+        if not target:
+                return Vector3i.ZERO
+        return Vector3i(target.global_transform.origin.round())


### PR DESCRIPTION
## Summary
- avoid per-frame O(n^2) overlap resolution by grouping ItemTags by world position
- ItemTagLayer maintains stacks and assigns offsets only when tags are added or removed
- clicking a tag now picks up the item

## Testing
- `gdlint scripts/items/item_tag.gd scripts/items/item_tag_layer.gd scripts/items/item_pickup.gd`

------
https://chatgpt.com/codex/tasks/task_e_68a3879349c0832db5c6d53029789c54