### PR TITLE
Handle offscreen item tags and safe restacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,19 @@ leave the camera's view. The `OffscreenCuller` script
 them once they are visible again, allowing large numbers of enemies without
 slowing the editor or game.
 
+## Item Tag System
+Dropped items display a nameplate that is projected from the active camera.
+Tags are managed by `ItemTagLayer`, which groups them by world position and
+assigns a stack index so overlapping items form a readable column. The layer
+only recalculates stacks when tags are added or removed and cleans up any
+freed tags to avoid crashes when items are picked up.
+
+Each `ItemPickup` adds a `VisibleOnScreenNotifier3D` that hides its tag while
+offscreen and restores it when the item returns to view. Showing the tag again
+causes the layer to re-stack the group so the label stays aligned with the
+item even after moving offscreen. This approach keeps per-frame work minimal
+while ensuring tags restack when items are collected or reappear.
+
 ## NPCs
 NPCs are non-combat characters the player can interact with. Clicking an NPC
 within range pauses the game, centers the camera on both characters and opens a

--- a/scripts/items/item_pickup.gd
+++ b/scripts/items/item_pickup.gd
@@ -8,6 +8,8 @@ extends Area3D
 var _player: Node
 var _tag: ItemTag
 var _layer: ItemTagLayer
+var _notifier: VisibleOnScreenNotifier3D
+var _tag_visible: bool = false
 
 func _ready() -> void:
 		connect("body_entered", _on_body_entered)
@@ -16,16 +18,23 @@ func _ready() -> void:
 		connect("mouse_exited", _on_mouse_exited)
 		connect("input_event", _on_input_event)
 
-		_layer = get_tree().get_root().get_node_or_null(item_tag_layer_path)
+                _layer = get_tree().get_root().get_node_or_null(item_tag_layer_path)
 
-		_tag = ItemTag.new()
-		_tag.target = self
-		_tag.set_item(item)
-		if _layer:
-				_layer.add_tag(_tag)
-		else:
-				add_child(_tag) # fallback so tag still appears during testing
-		_tag.connect("pressed", Callable(self, "_collect"))
+                _tag = ItemTag.new()
+                _tag.target = self
+                _tag.set_item(item)
+                if _layer:
+                                _layer.add_tag(_tag)
+                                _tag_visible = true
+                else:
+                                add_child(_tag) # fallback so tag still appears during testing
+                                _tag_visible = true
+                _tag.connect("pressed", Callable(self, "_collect"))
+
+                _notifier = VisibleOnScreenNotifier3D.new()
+                add_child(_notifier)
+                _notifier.connect("screen_exited", Callable(self, "_on_screen_exited"))
+                _notifier.connect("screen_entered", Callable(self, "_on_screen_entered"))
 
 func _on_body_entered(body: Node) -> void:
 		if body.has_method("add_item"):
@@ -36,7 +45,7 @@ func _on_body_exited(body: Node) -> void:
 				_player = null
 
 func _on_mouse_entered() -> void:
-		pass
+                pass
 
 func _on_mouse_exited() -> void:
 		pass
@@ -52,10 +61,28 @@ func _on_input_event(
 				_collect()
 
 func _collect() -> void:
-		if _player and item:
-				_player.add_item(item, amount)
-				if _layer and _tag:
-						_layer.remove_tag(_tag)
-				elif _tag:
-						_tag.queue_free()
-				get_parent().queue_free()
+                if _player and item:
+                                _player.add_item(item, amount)
+                                if _layer and _tag:
+                                                _layer.remove_tag(_tag)
+                                elif _tag:
+                                                _tag.queue_free()
+                                get_parent().queue_free()
+
+func _on_screen_exited() -> void:
+                if _tag_visible:
+                                if _layer and _tag:
+                                                _layer.hide_tag(_tag)
+                                elif _tag:
+                                                _tag.visible = false
+                                                _tag.set_process(false)
+                                _tag_visible = false
+
+func _on_screen_entered() -> void:
+                if not _tag_visible:
+                                if _layer and _tag:
+                                                _layer.show_tag(_tag)
+                                elif _tag:
+                                                _tag.visible = true
+                                                _tag.set_process(true)
+                                _tag_visible = true

--- a/scripts/items/item_tag.gd
+++ b/scripts/items/item_tag.gd
@@ -50,13 +50,14 @@ func set_stack_index(idx: int, spacing: float) -> void:
 		_stack_spacing = spacing
 
 func _process(_delta: float) -> void:
-		if not target or not is_instance_valid(target):
-				queue_free()
-				return
-		if not _camera:
-				_camera = get_viewport().get_camera_3d()
-				if not _camera:
-						return
+                if not target or not is_instance_valid(target):
+                                queue_free()
+                                return
+                var current_camera := get_viewport().get_camera_3d()
+                if not _camera or not is_instance_valid(_camera) or _camera != current_camera:
+                                _camera = current_camera
+                                if not _camera:
+                                                return
 
 		# Project the target's 3D position into 2D screen space.
 		var pos := target.global_transform.origin

--- a/scripts/items/item_tag_layer.gd
+++ b/scripts/items/item_tag_layer.gd
@@ -17,16 +17,36 @@ extends CanvasLayer
 # Dictionary mapping a world-position key to an array of tags at that location.
 var _groups: Dictionary = {}
 
-## Register a tag with the layer.  The tag will become a child of the layer and
-## automatically receive a stack index.
+## Register a tag with the layer so it becomes part of the stacking group.
+## This function is also used when an offscreen pickup becomes visible again
+## and needs to rejoin its group.
 func add_tag(tag: ItemTag) -> void:
-		add_child(tag)
-		_register_tag(tag)
+                show_tag(tag)
 
-## Remove a tag from the layer and update the remaining stack.
+## Permanently remove a tag from the layer and free it.
 func remove_tag(tag: ItemTag) -> void:
-		_unregister_tag(tag)
-		tag.queue_free()
+                hide_tag(tag)
+                tag.queue_free()
+
+## Temporarily hide a tag.  The tag stops processing and is removed from its
+## stacking group but remains in memory so it can be shown again later.
+func hide_tag(tag: ItemTag) -> void:
+                if not is_instance_valid(tag):
+                                return
+                _unregister_tag(tag)
+                tag.visible = false
+                tag.set_process(false)
+
+## Restore a previously hidden tag.  The tag is added back to the layer and the
+## stacking group is recalculated.
+func show_tag(tag: ItemTag) -> void:
+                if not is_instance_valid(tag):
+                                return
+                if tag.get_parent() != self:
+                                add_child(tag)
+                tag.visible = true
+                tag.set_process(true)
+                _register_tag(tag)
 
 ## Apply per-item styling such as colour and optional icon.
 func apply_style(tag: ItemTag) -> void:
@@ -47,30 +67,38 @@ func _get_style(item_type: String) -> ItemTagStyle:
 		return null
 
 func _register_tag(tag: ItemTag) -> void:
-		var key := _key_from_target(tag.target)
-		if not _groups.has(key):
-				_groups[key] = []
-		_groups[key].append(tag)
-		_restack_group(key)
+                var key := _key_from_target(tag.target)
+                if not _groups.has(key):
+                                _groups[key] = []
+                _groups[key].append(tag)
+                _restack_group(key)
 
 func _unregister_tag(tag: ItemTag) -> void:
-		var key := _key_from_target(tag.target)
-		if not _groups.has(key):
-				return
-		_groups[key].erase(tag)
-		if _groups[key].is_empty():
-				_groups.erase(key)
-		else:
-				_restack_group(key)
+                var key := _key_from_target(tag.target)
+                if not _groups.has(key):
+                                return
+                _groups[key].erase(tag)
+                if _groups[key].is_empty():
+                                _groups.erase(key)
+                else:
+                                _restack_group(key)
 
 func _restack_group(key: Vector3i) -> void:
-		var tags: Array = _groups.get(key, [])
-		for i in range(tags.size()):
-				(tags[i] as ItemTag).set_stack_index(i, vertical_spacing)
+                var tags: Array = _groups.get(key, [])
+                var i := 0
+                while i < tags.size():
+                                var tag: ItemTag = tags[i]
+                                if not is_instance_valid(tag) or not is_instance_valid(tag.target):
+                                                tags.remove_at(i)
+                                                continue
+                                tag.set_stack_index(i, vertical_spacing)
+                                i += 1
+                if tags.is_empty():
+                                _groups.erase(key)
 
 ## Generate a dictionary key based on an item's world position.  Rounding keeps
 ## nearby floating point values grouped together.
 func _key_from_target(target: Node3D) -> Vector3i:
-		if not target:
-				return Vector3i.ZERO
-		return Vector3i(target.global_transform.origin.round())
+                if not target or not is_instance_valid(target):
+                                return Vector3i.ZERO
+                return Vector3i(target.global_transform.origin.round())


### PR DESCRIPTION
## Summary
- Restack item tags safely by filtering freed nodes and exposing show/hide helpers in `ItemTagLayer`
- Refresh tag camera projection and add `VisibleOnScreenNotifier3D` to hide tags when offscreen
- Document item tag system and offscreen handling in README

## Testing
- `godot --headless --check` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68a38e877c44832d961d5134b1a773af