### PR TITLE
Improve item tag stacking and grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,13 +371,14 @@ item's affixes in its tooltip.
 
 ### Optimized Item Tags
 Item nameplates used to adjust their positions every frame to avoid overlapping
-with neighbouring tags.  This approach became expensive with many dropped items
-because each tag checked every other tag on the screen.  The `ItemTagLayer`
-now groups tags by the world position of their items and assigns each a stack
-index.  Individual `ItemTag` nodes simply project their item into screen space
-and apply this fixed offset.  Stacks are recalculated only when tags are added
-or removed, dramatically reducing per‑frame work while still presenting a
-readable column of names like in classic ARPGs.
+with neighbouring tags. This approach became expensive with many dropped items
+because each tag checked every other tag on the screen. The `ItemTagLayer`
+now groups tags by proximity and assigns each a stack position. Individual
+`ItemTag` nodes project their item into screen space and apply the precomputed
+offset. Stacks are recalculated only when tags are added or removed, and large
+stacks automatically spill into up to three columns when they would extend
+off screen. This keeps the system fast while presenting readable clusters of
+names like in classic ARPGs.
 
 ## Enemy Behavior
 Enemies now wander around randomly until the player gets close. When the player
@@ -443,16 +444,16 @@ slowing the editor or game.
 
 ## Item Tag System
 Dropped items display a nameplate that is projected from the active camera.
-Tags are managed by `ItemTagLayer`, which groups them by world position and
-assigns a stack index so overlapping items form a readable column. The layer
-only recalculates stacks when tags are added or removed and cleans up any
-freed tags to avoid crashes when items are picked up.
+Tags are managed by `ItemTagLayer`, which clusters nearby items into shared
+groups and assigns each tag a stack position. The layer only recalculates
+stacks when tags are added or removed and can distribute very large groups into
+multiple columns so labels remain visible.
 
 Each `ItemPickup` adds a `VisibleOnScreenNotifier3D` that hides its tag while
 offscreen and restores it when the item returns to view. Showing the tag again
-causes the layer to re-stack the group so the label stays aligned with the
-item even after moving offscreen. This approach keeps per-frame work minimal
-while ensuring tags restack when items are collected or reappear.
+re-registers it with the layer so the stack is recomputed and nearby groups are
+merged. This approach keeps per-frame work minimal while ensuring tags restack
+when items are collected or reappear.
 
 ## NPCs
 NPCs are non-combat characters the player can interact with. Clicking an NPC

--- a/scripts/items/item_pickup.gd
+++ b/scripts/items/item_pickup.gd
@@ -20,16 +20,17 @@ func _ready() -> void:
 
 		_layer = get_tree().get_root().get_node_or_null(item_tag_layer_path)
 
-		_tag = ItemTag.new()
-		_tag.target = self
-		_tag.set_item(item)
-		if _layer:
-						_layer.add_tag(_tag)
-						_tag_visible = true
-		else:
-						add_child(_tag) # fallback so tag still appears during testing
-						_tag_visible = true
-		_tag.connect("pressed", Callable(self, "_collect"))
+	_tag = ItemTag.new()
+	_tag.target = self
+	_tag.set_item(item)
+	await get_tree().process_frame
+	if _layer:
+		_layer.add_tag(_tag)
+		_tag_visible = true
+	else:
+		add_child(_tag) # fallback so tag still appears during testing
+		_tag_visible = true
+	_tag.connect("pressed", Callable(self, "_collect"))
 
 		_notifier = VisibleOnScreenNotifier3D.new()
 		add_child(_notifier)

--- a/scripts/items/item_tag.gd
+++ b/scripts/items/item_tag.gd
@@ -4,73 +4,89 @@ extends Button
 ## Node in charge of displaying a pickup's name above the item.
 ##
 ## Historically each tag tried to resolve overlaps with every other tag every
-## frame.  That resulted in an \(N^2\) cost as the number of dropped items
-## increased.  The new system stores a "stack index" computed by
+## frame.  That resulted in an (N^2) cost as the number of dropped items
+## increased.  The new system stores a stack position computed by
 ## `ItemTagLayer` when a tag is created or removed.  During `_process` we simply
-## project the target into screen space and apply the precomputed offset.  This
-## keeps the tags in a stable vertical stack while only performing the expensive
-## grouping logic when absolutely necessary.
+## project the target into screen space and apply the precomputed offsets.  This
+## keeps the tags in a stable stack while only performing the expensive grouping
+## logic when absolutely necessary.
 
 @export var vertical_offset: float = 1.5
 var item: Item
 var target: Node3D
 var _camera: Camera3D
 
-# Index within a stack of tags that occupy the same world position.
-var _stack_index: int = 0
-# Cached spacing between stacked tags provided by the layer.
-var _stack_spacing: float = 0.0
+# Position within a stack of tags calculated by the layer.
+var _stack_row: int = 0
+var _stack_col: int = 0
+var _stack_columns: int = 1
+var _stack_width: float = 0.0
+var _stack_height: float = 0.0
+var _v_spacing: float = 0.0
+var _h_spacing: float = 0.0
 
 func _ready() -> void:
-		_camera = get_viewport().get_camera_3d()
-		focus_mode = FOCUS_NONE
-		mouse_filter = Control.MOUSE_FILTER_STOP
-		size_flags_horizontal = Control.SIZE_SHRINK_CENTER
-		size_flags_vertical = Control.SIZE_SHRINK_CENTER
-		clip_text = false
+	_camera = get_viewport().get_camera_3d()
+	focus_mode = FOCUS_NONE
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	clip_text = false
 
 func set_item(it: Item) -> void:
-		item = it
-		text = it.item_name
-		var tip := "%s\n%s" % [it.item_name, it.description]
-		var aff_text := it.get_affix_text()
-		if aff_text != "":
-				tip += "\n" + aff_text
-		tooltip_text = tip
-		_apply_style()
+	item = it
+	text = it.item_name
+	var tip := "%s\n%s" % [it.item_name, it.description]
+	var aff_text := it.get_affix_text()
+	if aff_text != "":
+		tip += "\n" + aff_text
+	tooltip_text = tip
+	_apply_style()
 
 func _apply_style() -> void:
-				var layer := get_parent()
-				if layer and layer.has_method("apply_style"):
-								layer.apply_style(self)
+	var layer := get_parent()
+	if layer and layer.has_method("apply_style"):
+		layer.apply_style(self)
 
 ## Called by `ItemTagLayer` whenever the tag's stack position changes.
-func set_stack_index(idx: int, spacing: float) -> void:
-		_stack_index = idx
-		_stack_spacing = spacing
+func set_stack_coords(row: int, col: int, columns: int, width: float, height: float, v_spacing: float, h_spacing: float) -> void:
+	_stack_row = row
+	_stack_col = col
+	_stack_columns = columns
+	_stack_width = width
+	_stack_height = height
+	_v_spacing = v_spacing
+	_h_spacing = h_spacing
 
 func _process(_delta: float) -> void:
-		if not target or not is_instance_valid(target):
-						queue_free()
-						return
-		var current_camera := get_viewport().get_camera_3d()
-		if not _camera or not is_instance_valid(_camera) or _camera != current_camera:
-						_camera = current_camera
-						if not _camera:
-										return
+	if not target or not is_instance_valid(target):
+		queue_free()
+		return
+	var current_camera := get_viewport().get_camera_3d()
+	if not _camera or not is_instance_valid(_camera) or _camera != current_camera:
+		_camera = current_camera
+		if not _camera:
+			return
 
-		# Project the target's 3D position into 2D screen space.
-		var pos := target.global_transform.origin
-		pos.y += vertical_offset
-		var screen_point: Vector2 = _camera.unproject_position(pos)
+	# Project the target's 3D position into 2D screen space.
+	var pos := target.global_transform.origin
+	pos.y += vertical_offset
+	var screen_point: Vector2 = _camera.unproject_position(pos)
 
-		# Base position of the tag before applying the stack offset.
-		var base_pos := screen_point - size * 0.5
+	# Base position of the tag before applying stack offsets.
+	var base_pos := screen_point - size * 0.5
 
-		# Apply the vertical stack offset.  The layer provides the spacing in
-		# pixels so tags from the same world position form a readable column.
-		base_pos.y -= _stack_index * (size.y + _stack_spacing)
-		position = base_pos
+	# Apply vertical stack offset and center within row height.
+	base_pos.y -= _stack_row * (_stack_height + _v_spacing)
+	base_pos.y -= (_stack_height - size.y) * 0.5
 
-		# Tags are always visible; camera culling is handled elsewhere.
-		visible = true
+	# Apply horizontal offset. Center the whole group on the target.
+	var total_width := _stack_columns * _stack_width + (_stack_columns - 1) * _h_spacing
+	base_pos.x -= total_width * 0.5
+	base_pos.x += _stack_col * (_stack_width + _h_spacing)
+	base_pos.x += (_stack_width - size.x) * 0.5
+
+	position = base_pos
+
+	# Tags are always visible; camera culling is handled elsewhere.
+	visible = true

--- a/scripts/items/item_tag_layer.gd
+++ b/scripts/items/item_tag_layer.gd
@@ -4,18 +4,19 @@ extends CanvasLayer
 ## Central manager for item nameplates displayed above dropped items.
 ##
 ## Tags no longer attempt to resolve overlaps against their siblings every
-## frame.  Instead the layer groups tags by the world position of their target
-## `ItemPickup` and assigns each tag a stack index.  This index is used by
-## `ItemTag` to apply a fixed vertical offset in screen space, effectively
-## creating a column of labels for items that occupy the same location.  Because
-## items are static the stack only needs to be recalculated when tags are added
-## or removed.
+## frame. Instead the layer clusters tags by the world position of their target
+## and nearby neighbours, assigning each a stack index. `ItemTag` uses this
+## index to apply vertical offsets in screen space and can spread very tall
+## stacks into horizontal columns. Because items are static the stack only
+## needs to be recalculated when tags are added or removed.
 
 @export var vertical_spacing: float = 4.0
+@export var horizontal_spacing: float = 8.0
+@export var merge_distance: float = 1.5
 @export var tag_styles: Array[ItemTagStyle] = []
 
-# Dictionary mapping a world-position key to an array of tags at that location.
-var _groups: Dictionary = {}
+# Array of dictionaries: {position: Vector3, tags: Array[ItemTag]}
+var _groups: Array = []
 
 ## Register a tag with the layer so it becomes part of the stacking group.
 ## This function is also used when an offscreen pickup becomes visible again
@@ -32,7 +33,7 @@ func remove_tag(tag: ItemTag) -> void:
 ## stacking group but remains in memory so it can be shown again later.
 func hide_tag(tag: ItemTag) -> void:
 	if not is_instance_valid(tag):
-					return
+		return
 	_unregister_tag(tag)
 	tag.visible = false
 	tag.set_process(false)
@@ -41,66 +42,91 @@ func hide_tag(tag: ItemTag) -> void:
 ## stacking group is recalculated.
 func show_tag(tag: ItemTag) -> void:
 	if not is_instance_valid(tag):
-					return
+		return
 	if tag.get_parent() != self:
-					add_child(tag)
+		add_child(tag)
 	tag.visible = true
 	tag.set_process(true)
-	_register_tag(tag)
+	# Defer registration so the tag's size is valid before stacking.
+	call_deferred("_register_tag", tag)
 
 ## Apply per-item styling such as colour and optional icon.
 func apply_style(tag: ItemTag) -> void:
-		if not tag.item:
-				return
-		var style := _get_style(tag.item.item_type)
-		if style:
-				tag.add_theme_color_override("font_color", style.color)
-				if style.icon:
-						tag.icon = style.icon
+	if not tag.item:
+		return
+	var style := _get_style(tag.item.item_type)
+	if style:
+		tag.add_theme_color_override("font_color", style.color)
+		if style.icon:
+			tag.icon = style.icon
 
 # --- Internal helpers -------------------------------------------------------
 
 func _get_style(item_type: String) -> ItemTagStyle:
-		for style in tag_styles:
-				if style.item_type == item_type:
-						return style
-		return null
+	for style in tag_styles:
+		if style.item_type == item_type:
+			return style
+	return null
 
 func _register_tag(tag: ItemTag) -> void:
-	var key := _key_from_target(tag.target)
-	if not _groups.has(key):
-					_groups[key] = []
-	_groups[key].append(tag)
-	_restack_group(key)
+	var pos: Vector3 = tag.target.global_transform.origin
+	var merged_tags: Array = [tag]
+	var merged_pos: Vector3 = pos
+	var to_remove: Array = []
+	for group in _groups:
+		if group.position.distance_to(pos) <= merge_distance:
+			merged_tags.append_array(group.tags)
+			merged_pos = (merged_pos + group.position) * 0.5
+			to_remove.append(group)
+	for g in to_remove:
+		_groups.erase(g)
+	var new_group := {"position": merged_pos, "tags": merged_tags}
+	_groups.append(new_group)
+	_restack_group(new_group)
 
 func _unregister_tag(tag: ItemTag) -> void:
-	var key := _key_from_target(tag.target)
-	if not _groups.has(key):
-					return
-	_groups[key].erase(tag)
-	if _groups[key].is_empty():
-					_groups.erase(key)
-	else:
-					_restack_group(key)
+	for group in _groups:
+		if group.tags.has(tag):
+			group.tags.erase(tag)
+			if group.tags.is_empty():
+				_groups.erase(group)
+			else:
+				group.position = _average_position(group.tags)
+				_restack_group(group)
+			return
 
-func _restack_group(key: Vector3i) -> void:
-	var tags: Array = _groups.get(key, [])
-	var i := 0
+func _restack_group(group: Dictionary) -> void:
+	var tags: Array = group.tags
 	tags = tags.filter(func(t):
 		return is_instance_valid(t) and is_instance_valid(t.target))
-	while i < tags.size():
-					var tag: ItemTag = tags[i]
-					if not is_instance_valid(tag) or not is_instance_valid(tag.target):
-									tags.remove_at(i)
-									continue
-					tag.set_stack_index(i, vertical_spacing)
-					i += 1
+	group.tags = tags
 	if tags.is_empty():
-					_groups.erase(key)
+		_groups.erase(group)
+		return
+	var max_w := 0.0
+	var max_h := 0.0
+	for t in tags:
+		max_w = max(max_w, t.size.x)
+		max_h = max(max_h, t.size.y)
+	if max_w <= 0.0:
+		max_w = 64.0
+	if max_h <= 0.0:
+		max_h = 16.0
+	var viewport_height := get_viewport().size.y
+	var row_height := max_h + vertical_spacing
+	var rows_per_col := max(1, int(floor(viewport_height / row_height)))
+	var columns := 1
+	if tags.size() > rows_per_col:
+		columns = min(3, int(ceil(float(tags.size()) / rows_per_col)))
+	for i in range(tags.size()):
+		var row := i % rows_per_col
+		var col := i / rows_per_col
+		var tag: ItemTag = tags[i]
+		tag.set_stack_coords(row, col, columns, max_w, max_h, vertical_spacing, horizontal_spacing)
 
-## Generate a dictionary key based on an item's world position.  Rounding keeps
-## nearby floating point values grouped together.
-func _key_from_target(target: Node3D) -> Vector3i:
-	if not target or not is_instance_valid(target):
-					return Vector3i.ZERO
-	return Vector3i(target.global_transform.origin.round())
+func _average_position(tags: Array) -> Vector3:
+	var sum := Vector3.ZERO
+	for t in tags:
+		if is_instance_valid(t) and is_instance_valid(t.target):
+			sum += t.target.global_transform.origin
+	return sum / max(tags.size(), 1)


### PR DESCRIPTION
## Summary
- cluster nearby item tags and split tall stacks into horizontal columns
- add stack coordinate handling to ItemTag and await tag creation in ItemPickup
- document new tag behaviour in README

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a305fdd0832daee94e93a50f80af