### PR TITLE
Add runtime tile level generation via portal

### DIFF
--- a/scripts/tile_levels/tile_level_generator.gd
+++ b/scripts/tile_levels/tile_level_generator.gd
@@ -7,6 +7,8 @@ extends RefCounted
 # The generator now also places a `PlayerSpawn` marker in the first room,
 # optionally instantiates a boss in the farthest room and can populate any
 # interior tiles with enemies supplied via `TileLevelSettings`.
+# The returned root node is named `GeneratedLevel` so gameplay code can locate
+# and replace the existing level at runtime.
 # All generated instances receive unique names to satisfy the Godot 4.4
 # requirement that sibling nodes have distinct names, preventing editor warnings
 # like "An incoming node's name clashes with..." when saving or loading scenes.
@@ -57,9 +59,13 @@ func generate(settings: TileLevelSettings) -> Node3D:
 
 	print("Obstacles added, connections ensured")
 
-	var root := Node3D.new()
-		# Set the owner so every spawned node belongs to this scene when packed.
-	#root.owner = root
+        # Top-level node containing the entire generated level. Naming it
+        # `GeneratedLevel` allows gameplay code to easily find and replace the
+        # current level at runtime.
+        var root := Node3D.new()
+        root.name = "GeneratedLevel"
+                # Set the owner so every spawned node belongs to this scene when packed.
+        #root.owner = root
 	var default_positions: Array[Vector2i] = []
 	var outside_rects: Array[Rect2] = []
 	

--- a/scripts/tile_levels/tile_level_runtime.gd
+++ b/scripts/tile_levels/tile_level_runtime.gd
@@ -1,0 +1,38 @@
+class_name TileLevelRuntime
+extends Node
+
+## Runtime helper that builds a procedural level from a
+## `TileLevelSettings` resource. This mirrors the editor-only
+## `TileLevelPreview` but is safe to use in-game.
+##
+## Call `generate()` to produce a level node or `generate_into(parent)`
+## to add it directly to the scene tree. The returned node will be
+## named `GeneratedLevel` by `TileLevelGenerator`.
+
+@export_file("*.tres") var settings_path: String = "res://resources/level_gen/floating_islands.tres"
+
+func _load_settings() -> TileLevelSettings:
+    if settings_path == "":
+        push_error("TileLevelRuntime: settings_path is empty")
+        return null
+    var settings: TileLevelSettings = load(settings_path)
+    if not settings:
+        push_error("TileLevelRuntime: could not load settings resource")
+    return settings
+
+## Generates a level and returns the root node without adding it to the
+## scene tree.
+func generate() -> Node3D:
+    var settings := _load_settings()
+    if not settings:
+        return null
+    var generator := TileLevelGenerator.new()
+    return generator.generate(settings)
+
+## Generates a level and adds it as a child of `parent`. The generated
+## node is returned for convenience.
+func generate_into(parent: Node) -> Node3D:
+    var level := generate()
+    if level and parent:
+        parent.add_child(level)
+    return level


### PR DESCRIPTION
## Summary
- Enable `TileLevelGenerator` to name its root node `GeneratedLevel` for easy runtime replacement
- Add `TileLevelRuntime` helper and update `Portal` to generate new levels, move player and respawn portal after boss death
- Document procedural portal flow and runtime generator in README

## Testing
- `./godot-bin/Godot_v4.2.1-stable_linux.x86_64 --headless --check-only --path .` *(fails: Resource file not found: uid://dduutvhpgaapk)*

------
https://chatgpt.com/codex/tasks/task_e_68a3feca8640832daee8e6e69296ed5f