### PR TITLE
Fix item crafting side effects and support dual ring slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,20 @@ To create a jewel in Godot 4.4, make a new `.tres` Resource using
 Icons can be assigned like the existing `chaos_orb.tres` under
 `resources/items/currency/`.
 
+### Item Instances and Equipment Slots
+Items picked up from the world are now duplicated so their affixes are unique
+per instance. This prevents crafting on one item from modifying every copy of
+the same resource. When placing `ItemPickup` scenes manually, mark the exported
+`item` resource as **Local To Scene (Unique)** in the inspector to avoid shared
+references.
+
+`EquipmentManager` supports multiple slots of the same type. Calling
+`set_slots(["weapon", "offhand", "armor", "helmet", "ring", "ring"])` creates two
+independent ring slots. Inventory equipment slots automatically receive an
+index, but it can be overridden in the editor if a specific ordering is
+required. Ensure ring slot `InventorySlot` nodes have `is_equipment` checked and
+`slot_type` set to `"ring"`.
+
 ### Displaying Affixes
 Hovering over an item tag in the world or over an inventory slot now shows the
 item's affixes in its tooltip.

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -302,8 +302,14 @@ func _drop_loot() -> void:
 				if randf() <= float(entry.get("chance", 1.0)):
 						var drop := drop_scene.instantiate()
 						var area := drop.get_node_or_null("Area3D")
-						if area and entry.has("item"):
-								area.item = entry["item"]
+                                                if area and entry.has("item"):
+                                                                var it: Item = entry["item"]
+                                                                # Duplicate non-stackable items so affix crafting on one drop
+                                                                # doesn't modify other instances.
+                                                                if it and it.max_stack <= 1:
+                                                                        area.item = it.duplicate(true)
+                                                                else:
+                                                                        area.item = it
 						if area and entry.has("amount"):
 								area.amount = entry["amount"]
 						get_parent().add_child(drop)

--- a/scripts/items/equipment_manager.gd
+++ b/scripts/items/equipment_manager.gd
@@ -2,52 +2,77 @@ extends Node
 class_name EquipmentManager
 
 # Handles equipping and unequipping of items and applies their affixes to a
-# `Stats` instance.  The manager keeps track of items by slot name and emits a
-# signal whenever a slot changes.
+# `Stats` instance. The manager supports multiple slots of the same type (e.g.
+# two "ring" slots) and emits a signal whenever a slot changes.
 
-signal slot_changed(slot: String, item: Item)
+signal slot_changed(slot: String, index: int, item: Item)
 
 @export var stats: Stats
 
-# Dictionary of slot -> Item. Slots are created via `set_slots`.
+# Dictionary mapping slot type -> array of items. Duplicate slot types create
+# additional entries in the array so we can have, for example, two "ring" slots.
 var _slots: Dictionary = {}
 
 func set_slots(names: Array) -> void:
-	# Initializes the available equipment slots. Call once on setup.
-	for n in names:
-		_slots[n] = null
+        # Initializes available equipment slots. Each entry in `names` is a slot
+        # type ("weapon", "ring", etc.). Duplicate entries create multiple slots
+        # of the same type.
+        for n in names:
+                if _slots.has(n):
+                        _slots[n].append(null)
+                else:
+                        _slots[n] = [null]
 
-func get_item(slot: String) -> Item:
-		return _slots.get(slot, null)
+func get_item(slot: String, index: int = 0) -> Item:
+                var arr: Array = _slots.get(slot, [])
+                if index >= 0 and index < arr.size():
+                        return arr[index]
+                return null
 
 func get_all_items() -> Array:
-		## Returns an array of all items currently equipped across all slots.
-		## The array may contain `null` for empty slots.  Useful for systems
-		## that need to query every equipped item, such as hiding the player's
-		## hair when a helmet is worn.  Introduced for Godot 4.4 integration.
-		return _slots.values()
+                ## Returns an array of all items currently equipped across all
+                ## slots. The array may contain `null` for empty slots. Useful for
+                ## systems that need to query every equipped item, such as hiding
+                ## the player's hair when a helmet is worn.
+                var result: Array = []
+                for arr in _slots.values():
+                        result.append_array(arr)
+                return result
 
-func equip(item: Item) -> Item:
-	# Equips the given item and returns any item that was previously in the slot.
-	if not item or item.equip_slot == "":
-		return null
-	var slot := item.equip_slot
-	var previous: Item = _slots.get(slot, null)
-	if previous:
-		_remove_item(previous)
-	_slots[slot] = item
-	_apply_item(item)
-	emit_signal("slot_changed", slot, item)
-	return previous
+func equip(item: Item, index: int = -1) -> Item:
+        # Equips the given item and returns any item that was previously in the
+        # slot. When `index` is -1 the first free slot of the matching type is
+        # used.
+        if not item or item.equip_slot == "":
+                return null
+        var slot := item.equip_slot
+        var arr: Array = _slots.get(slot, [])
+        if arr.is_empty():
+                return null
+        var slot_index := index
+        if slot_index < 0 or slot_index >= arr.size():
+                slot_index = arr.find(null)
+                if slot_index == -1:
+                        slot_index = 0
+        var previous: Item = arr[slot_index]
+        if previous:
+                _remove_item(previous)
+        arr[slot_index] = item
+        _apply_item(item)
+        emit_signal("slot_changed", slot, slot_index, item)
+        return previous
 
-func unequip(slot: String) -> Item:
-	# Removes the item from the slot and returns it.
-	var item: Item = _slots.get(slot, null)
-	if item:
-		_remove_item(item)
-		_slots[slot] = null
-		emit_signal("slot_changed", slot, null)
-	return item
+func unequip(slot: String, index: int = 0) -> Item:
+        # Removes the item from the slot and returns it.
+        var arr: Array = _slots.get(slot, [])
+        if index < 0 or index >= arr.size():
+                return null
+        var item: Item = arr[index]
+        if item:
+                _remove_item(item)
+                arr[index] = null
+                emit_signal("slot_changed", slot, index, null)
+        return item
 
 # -- Internal helpers -------------------------------------------------------
 

--- a/scripts/items/equipment_visual_manager.gd
+++ b/scripts/items/equipment_visual_manager.gd
@@ -41,8 +41,8 @@ var _attachments: Dictionary = {}
 var _hair_instance: Node3D
 
 func _ready() -> void:
-	if equipment:
-			equipment.connect("slot_changed", _on_slot_changed)
+        if equipment:
+                        equipment.connect("slot_changed", _on_slot_changed)
 	# Pre-create attachment points for mapped slots.
 	if skeleton:
 			for slot in SLOT_BONES.keys():
@@ -61,55 +61,53 @@ func _ready() -> void:
 					skeleton.add_child(_hair_instance)
 	_update_hair_visibility()
 
-func _on_slot_changed(slot: String, item: Item) -> void:
-	## Remove existing model for this slot and attach the new one if any.
-	_clear_slot(slot)
-	if not item or item.model == null:
-				print("no item or no item model")
-				_update_hair_visibility()
-				return
-	var instance: Node3D = item.model.instantiate()
-	if slot == "armor":
-		_equip_armor(instance)
-	elif slot in SLOT_BONES:
-			print("equipping ", item.item_name, " in ", slot, " slot")
-			_attachments[slot].add_child(instance)
-			var local_xform := Transform3D(Basis.from_euler(item.equip_rotation_rads), item.equip_position)
-			instance.transform = local_xform
-			#skeleton.add_child(instance)
-			_models[slot] = instance
-			#instance.transform = item.equip_transform
-	else:
-			skeleton.add_child(instance)
-			_models[slot] = instance
-			#instance.transform = item.equip_transform
-	_update_hair_visibility()
+func _on_slot_changed(slot: String, index: int, item: Item) -> void:
+        ## Remove existing model for this slot and attach the new one if any.
+        var key := "%s_%d" % [slot, index]
+        _clear_slot(key)
+        if not item or item.model == null:
+                                print("no item or no item model")
+                                _update_hair_visibility()
+                                return
+        var instance: Node3D = item.model.instantiate()
+        if slot == "armor":
+                _equip_armor(instance, key)
+        elif slot in SLOT_BONES:
+                        print("equipping ", item.item_name, " in ", slot, " slot")
+                        _attachments[slot].add_child(instance)
+                        var local_xform := Transform3D(Basis.from_euler(item.equip_rotation_rads), item.equip_position)
+                        instance.transform = local_xform
+                        _models[key] = instance
+        else:
+                        skeleton.add_child(instance)
+                        _models[key] = instance
+        _update_hair_visibility()
 
 func _clear_slot(slot: String) -> void:
-	var model = _models.get(slot, null)
-	if model:
-		if model is Array:
-			for m in model:
+        var model = _models.get(slot, null)
+        if model:
+                if model is Array:
+                        for m in model:
 				if is_instance_valid(m):
 					m.queue_free()
 		elif is_instance_valid(model):
 			model.queue_free()
 		_models.erase(slot)
 
-func _equip_armor(root: Node3D) -> void:
-	## Attach an armour model by retargeting all MeshInstance3D nodes to the
-	## player's skeleton.  The original scene is freed after extraction.
-	print("equipping armor?")
-	var meshes: Array = []
-	_collect_meshes(root, meshes)
-	for m in meshes:
-		var global_xform: Transform3D = m.global_transform
-		skeleton.add_child(m)
-		m.global_transform = global_xform
-		m.skeleton = m.get_path_to(skeleton)
-		m.scale = Vector3(100, 100, 100)
-	root.queue_free()
-	_models["armor"] = meshes
+func _equip_armor(root: Node3D, key: String) -> void:
+        ## Attach an armour model by retargeting all MeshInstance3D nodes to the
+        ## player's skeleton. The original scene is freed after extraction.
+        print("equipping armor?")
+        var meshes: Array = []
+        _collect_meshes(root, meshes)
+        for m in meshes:
+                var global_xform: Transform3D = m.global_transform
+                skeleton.add_child(m)
+                m.global_transform = global_xform
+                m.skeleton = m.get_path_to(skeleton)
+                m.scale = Vector3(100, 100, 100)
+        root.queue_free()
+        _models[key] = meshes
 
 func _collect_meshes(node: Node, out: Array) -> void:
 		## Recursively gather MeshInstance3D nodes from `node` into `out`.

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -123,11 +123,14 @@ func _ready() -> void:
 	stats.base_mana_regen = base_mana_regen
 	stats.base_attack_speed = base_attack_speed
 
-	equipment = EquipmentManager.new()
-	equipment.stats = stats
-	equipment.set_slots(["weapon", "offhand", "armor", "helmet"])
-	equipment.connect("slot_changed", Callable(self, "_on_equipment_slot_changed"))
-	add_child(equipment)
+        equipment = EquipmentManager.new()
+        equipment.stats = stats
+        # Create equipment slots.  Rings use the same "ring" slot type but
+        # appear twice so the player can wear one on each hand.
+        # `EquipmentManager` will treat duplicate entries as separate slots.
+        equipment.set_slots(["weapon", "offhand", "armor", "helmet", "ring", "ring"])
+        equipment.connect("slot_changed", Callable(self, "_on_equipment_slot_changed"))
+        add_child(equipment)
 
 	# Visual manager displays meshes for equipped items.
 	var skeleton: Skeleton3D = get_node_or_null(skeleton_path)
@@ -421,11 +424,12 @@ func set_skill_slot(_index: int, _skill: Skill) -> void:
 		pass
 
 ## Equip slot callback. When a weapon is equipped, apply its default skill if provided.
-func _on_equipment_slot_changed(slot: String, item: Item) -> void:
-		if slot != "weapon":
-				return
-		if item is Weapon and item.default_skill:
-				main_skill = item.default_skill
+func _on_equipment_slot_changed(slot: String, index: int, item: Item) -> void:
+                # Only react when the primary weapon slot changes.
+                if slot != "weapon":
+                                return
+                if item is Weapon and item.default_skill:
+                                main_skill = item.default_skill
 
 ## Returns a dictionary of base damage contributed by the equipped weapon for
 ## skills with the given tags.
@@ -463,10 +467,16 @@ func get_attack_speed(tags: Array[String] = []) -> float:
 		return speed
 
 func add_item(item: Item, amount: int = 1) -> void:
-	if _inventory_open and _inventory_ui:
-		_inventory_ui.pickup_to_cursor(item, amount)
-	else:
-		inventory.add_item(item, amount)
+        # When picking up equipment we duplicate the resource so currency
+        # crafting only affects this instance. Stackable items like currency
+        # keep their original resource so they can merge in the inventory.
+        var inst := item
+        if inst and inst.max_stack <= 1:
+                inst = inst.duplicate(true)
+        if _inventory_open and _inventory_ui:
+                _inventory_ui.pickup_to_cursor(inst, amount)
+        else:
+                inventory.add_item(inst, amount)
 
 func take_damage(amount: float, damage_type: Stats.DamageType = Stats.DamageType.PHYSICAL) -> void:
 	if _invincible_timer > 0.0:

--- a/scripts/ui/inventory_slot.gd
+++ b/scripts/ui/inventory_slot.gd
@@ -10,6 +10,8 @@ signal right_clicked(index: int)
 @export var is_equipment: bool = false
 @export var slot_type: String = ""
 
+# Index distinguishes multiple equipment slots of the same type (e.g. ring 0
+# and ring 1). InventoryUI will auto-assign if left at the default value.
 @export var index: int = -1
 var item: Item = null
 var amount: int = 0

--- a/scripts/ui/inventory_ui.gd
+++ b/scripts/ui/inventory_ui.gd
@@ -118,8 +118,8 @@ func _on_slot_changed(index: int, item: Item, amount: int) -> void:
 		slot.set_amount(amount)
 
 
-func _on_equip_slot_changed(_slot: String, _item: Item) -> void:
-	_update_equip_slots()
+func _on_equip_slot_changed(_slot: String, _index: int, _item: Item) -> void:
+        _update_equip_slots()
 
 func _on_rune_slot_changed(_slot_index: int, _rune_index: int, _rune: Rune) -> void:
 	_update_rune_slots()
@@ -197,37 +197,39 @@ func _on_slot_right_clicked(index: int) -> void:
 
 
 func _on_equip_slot_pressed(_index: int, slot: InventorySlot) -> void:
-	if not _equipment:
-		return
-	if _cursor_item:
-		if _cursor_item.equip_slot == slot.slot_type:
-			var swapped = _equipment.equip(_cursor_item)
-			_cursor_item = null
-			_cursor_amount = 0
-			if swapped:
-				_cursor_item = swapped
-				_cursor_amount = 1
-			_update_cursor()
-			_update_equip_slots()
-			_update_rune_slots()
-	else:
-		var item = _equipment.unequip(slot.slot_type)
-		if item:
-			_cursor_item = item
-			_cursor_amount = 1
-		_update_cursor()
-		_update_equip_slots()
+        if not _equipment:
+                return
+        if _cursor_item:
+                if _cursor_item.equip_slot == slot.slot_type:
+                        # Pass the slot index so duplicate slot types (e.g. rings)
+                        # equip correctly.
+                        var swapped = _equipment.equip(_cursor_item, slot.index)
+                        _cursor_item = null
+                        _cursor_amount = 0
+                        if swapped:
+                                _cursor_item = swapped
+                                _cursor_amount = 1
+                        _update_cursor()
+                        _update_equip_slots()
+                        _update_rune_slots()
+        else:
+                var item = _equipment.unequip(slot.slot_type, slot.index)
+                if item:
+                        _cursor_item = item
+                        _cursor_amount = 1
+                _update_cursor()
+                _update_equip_slots()
 
 
 func _on_equip_slot_right_clicked(_index: int, slot: InventorySlot) -> void:
-	if not _equipment or not _inventory:
-		return
-	var item = _equipment.unequip(slot.slot_type)
-	if item:
-		_inventory.add_item(item)
-		_update_slots()
-		_update_equip_slots()
-		_update_rune_slots()
+        if not _equipment or not _inventory:
+                return
+        var item = _equipment.unequip(slot.slot_type, slot.index)
+        if item:
+                _inventory.add_item(item)
+                _update_slots()
+                _update_equip_slots()
+                _update_rune_slots()
 
 func _on_rune_slot_pressed(slot: RuneSlot) -> void:
 	if not _rune_manager:
@@ -273,14 +275,15 @@ func _update_slots() -> void:
 
 
 func _update_equip_slots() -> void:
-	if not _equipment:
-		return
-	for slot in _equip_slots:
-		var item = _equipment.get_item(slot.slot_type)
-		if slot.has_method("set_item"):
-			slot.set_item(item)
-		if slot.has_method("set_amount"):
-			slot.set_amount(1 if item else 0)
+        if not _equipment:
+                return
+        for slot in _equip_slots:
+                # Fetch item using slot index so duplicate slot types work.
+                var item = _equipment.get_item(slot.slot_type, slot.index)
+                if slot.has_method("set_item"):
+                        slot.set_item(item)
+                if slot.has_method("set_amount"):
+                        slot.set_amount(1 if item else 0)
 
 func _update_rune_slots() -> void:
 	if not _rune_manager:
@@ -323,26 +326,34 @@ func _update_cursor_visibility() -> void:
 	_cursor_icon.visible = _cursor_item != null and _open
 
 func _collect_slots() -> void:
-	_slots.clear()
-	_equip_slots.clear()
-	_rune_slots.clear()
-	var inv_slots: Array = find_children("*", "InventorySlot", true)
-	var inv_index := 0
-	for slot in inv_slots:
-		if slot.is_equipment:
-			_equip_slots.append(slot)
-			if slot.has_signal("pressed"):
-				slot.connect("pressed", Callable(self, "_on_equip_slot_pressed").bind(slot))
-			if slot.has_signal("right_clicked"):
-				slot.connect("right_clicked", Callable(self, "_on_equip_slot_right_clicked").bind(slot))
-		else:
-			slot.index = inv_index
-			inv_index += 1
-			_slots.append(slot)
-			if slot.has_signal("pressed"):
-				slot.connect("pressed", Callable(self, "_on_slot_pressed"))
-			if slot.has_signal("right_clicked"):
-				slot.connect("right_clicked", Callable(self, "_on_slot_right_clicked"))
+        _slots.clear()
+        _equip_slots.clear()
+        _rune_slots.clear()
+        var inv_slots: Array = find_children("*", "InventorySlot", true)
+        var inv_index := 0
+        var equip_counts := {}
+        for slot in inv_slots:
+                if slot.is_equipment:
+                        # Automatically assign an index to equipment slots if one
+                        # isn't provided so multiple slots of the same type (like
+                        # rings) can be distinguished.
+                        if slot.index < 0:
+                                var count := equip_counts.get(slot.slot_type, 0)
+                                slot.index = count
+                                equip_counts[slot.slot_type] = count + 1
+                        _equip_slots.append(slot)
+                        if slot.has_signal("pressed"):
+                                slot.connect("pressed", Callable(self, "_on_equip_slot_pressed").bind(slot))
+                        if slot.has_signal("right_clicked"):
+                                slot.connect("right_clicked", Callable(self, "_on_equip_slot_right_clicked").bind(slot))
+                else:
+                        slot.index = inv_index
+                        inv_index += 1
+                        _slots.append(slot)
+                        if slot.has_signal("pressed"):
+                                slot.connect("pressed", Callable(self, "_on_slot_pressed"))
+                        if slot.has_signal("right_clicked"):
+                                slot.connect("right_clicked", Callable(self, "_on_slot_right_clicked"))
 
 	var rslots: Array = find_children("*", "RuneSlot", true)
 	for rslot in rslots:


### PR DESCRIPTION
## Summary
- Duplicate non-stackable items on drop/pickup so crafting currency affects only the picked instance
- Expand equipment manager/UI to handle multiple slots of the same type, enabling two ring slots
- Document item instance behavior and ring slot setup

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68a50d1a9578832d9a94909281c63683