### PR TITLE
Refine minimap fog and wall rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,10 +612,10 @@ tile_level_runtime.gd` wraps this logic and exposes an exportable
 `scripts/tile_levels/tile_level_preview.gd` is an `EditorScript` that can generate a `.tscn` from a settings resource. Open the script in Godot, set `settings_path` and `output_path`, then run it from the editor to inspect a sample generation.
 
 ## Minimap and Fog of War
-The level generator now exposes grid data on the `GeneratedLevel` root so runtime
-scripts can reconstruct the map. A new `Minimap` control (`scripts/ui/minimap.gd`)
-renders a scaled image of the walkable tiles and gradually reveals it as the
-player explores.
+The level generator exposes grid data on the `GeneratedLevel` root so runtime
+scripts can reconstruct the map. A `Minimap` control (`scripts/ui/minimap.gd`)
+draws only the walls of discovered tiles over a transparent background. Walls
+remain visible once uncovered, giving the player a sense of explored space.
 
 ### Setup
 1. In the **Main** scene add a `CanvasLayer` with a `Control` node sized and
@@ -623,11 +623,13 @@ player explores.
    corner).
 2. Attach `scripts/ui/minimap.gd` to this `Control`.
 3. In the Inspector set **player_path** to your Player node. Adjust
-   **map_scale** and **enemy_reveal_distance** as desired.
+   **map_scale**, **enemy_reveal_distance**, **wall_color**, and the fog
+   **reveal_radius** as desired.
 
 The minimap automatically detects when a new `GeneratedLevel` is added to the
-scene tree. Walkable tiles are drawn in white while undiscovered areas remain
-black. The tile under the player is revealed each frame, lifting the fog in a
-classic "fog of war" style. Nearby enemies appear as red dots; bosses use a
-magenta icon once their tile has been uncovered.
+scene tree. Only walls bordering non‑walkable space are drawn, gradually
+appearing as the player moves. The fog of war reveals tiles within
+**reveal_radius** of the player each frame. Enemies appear as red dots and the
+player icon is blue; bosses retain a magenta icon once their tile has been
+uncovered.
 

--- a/scripts/ui/minimap.gd
+++ b/scripts/ui/minimap.gd
@@ -7,23 +7,22 @@ moves and overlays icons for nearby enemies and the boss once discovered.
 Attach this script to a Control node. Set its size/anchors in the editor.
 """
 
-@export var player_path: NodePath  ## Path to the player Node3D.
+@export var player_path: NodePath  ## Path to the player `Node3D`.
 @export var map_scale: float = 4.0  ## Pixel size for each tile on the map.
 @export var enemy_reveal_distance: float = 30.0  ## World units to show enemies.
-@export var tile_color: Color = Color(1, 1, 1)
-@export var player_color: Color = Color(0.2, 0.6, 1)
-@export var enemy_color: Color = Color(1, 0, 0)
-@export var boss_color: Color = Color(1, 0, 1)
+@export var wall_color: Color = Color(0.5, 0.7, 1, 0.8)  ## Color for walls on the map.
+@export var player_color: Color = Color(0.2, 0.6, 1)  ## Player icon color.
+@export var enemy_color: Color = Color(1, 0, 0)  ## Enemy icon color.
+@export var boss_color: Color = Color(1, 0, 1)  ## Boss icon color.
+@export var reveal_radius: int = 3  ## Radius (in tiles) for fog-of-war revealing.
 
 var _player: Node3D
 var _level: Node3D
 var _level_size: Vector2i = Vector2i.ZERO
 var _tile_size: float = 1.0
 var _walkable_tiles: Array = []
-var _discovered := {}
-var _map_tex: Texture2D
-var _fog_image: Image
-var _fog_tex: Texture2D
+var _walkable := {}  ## Dictionary for quick lookups of walkable tiles.
+var _discovered := {}  ## Tiles that have been revealed by the player.
 
 
 func _ready() -> void:
@@ -46,86 +45,116 @@ func _on_node_added(node: Node) -> void:
 func _on_node_removed(node: Node) -> void:
 	if node == _level:
 		_level = null
-		_walkable_tiles.clear()
-		_level_size = Vector2i.ZERO
-		_discovered.clear()
-		queue_redraw()
+                _walkable_tiles.clear()
+                _walkable.clear()
+                _level_size = Vector2i.ZERO
+                _discovered.clear()
+                queue_redraw()
 
 
 func _set_level(level: Node3D) -> void:
 	print("SETTING LEVEL")
 	_level = level
-	_walkable_tiles = level.get_meta("walkable_tiles", [])
-	_level_size = level.get_meta("level_size", Vector2i.ZERO)
-	_tile_size = level.get_meta("tile_size", 1.0)
-	_discovered.clear()
+        _walkable_tiles = level.get_meta("walkable_tiles", [])
+        _walkable.clear()
+        for p in _walkable_tiles:
+                _walkable[p] = true
+        _level_size = level.get_meta("level_size", Vector2i.ZERO)
+        _tile_size = level.get_meta("tile_size", 1.0)
+        _discovered.clear()
 
-	var img := Image.create(_level_size.x, _level_size.y, false, Image.FORMAT_RGBA8)
-	img.fill(Color(0, 0, 0, 0))
-	for p in _walkable_tiles:
-		img.set_pixelv(p, tile_color)
-	_map_tex = ImageTexture.create_from_image(img)
-
-	_fog_image = Image.create(_level_size.x, _level_size.y, false, Image.FORMAT_RGBA8)
-	_fog_image.fill(Color.BLACK)
-	_fog_tex = ImageTexture.create_from_image(_fog_image)
-
-	custom_minimum_size = Vector2(_level_size) * map_scale
-	queue_redraw()
+        # The minimap itself is transparent, so we simply size the Control.
+        custom_minimum_size = Vector2(_level_size) * map_scale
+        queue_redraw()
 
 
 func _process(_delta: float) -> void:
 	if not _player or not _level:
 		return
-	var tile := Vector2i(
-		int(floor(_player.global_position.x / _tile_size)),
-		int(floor(_player.global_position.z / _tile_size))
-	)
-	if _walkable_tiles.has(tile) and not _discovered.has(tile):
-		_reveal(tile)
-	queue_redraw()
+        var tile := Vector2i(
+                int(floor(_player.global_position.x / _tile_size)),
+                int(floor(_player.global_position.z / _tile_size))
+        )
+        var radius_sq := reveal_radius * reveal_radius
+        for x in range(tile.x - reveal_radius, tile.x + reveal_radius + 1):
+                for y in range(tile.y - reveal_radius, tile.y + reveal_radius + 1):
+                        var p := Vector2i(x, y)
+                        var d := p - tile
+                        if d.length_squared() > radius_sq:
+                                continue
+                        if _walkable.has(p) and not _discovered.has(p):
+                                _reveal(p)
+        queue_redraw()
 
 
 func _reveal(tile: Vector2i) -> void:
-	_discovered[tile] = true
-	_fog_image.set_pixelv(tile, Color(0, 0, 0, 0))
-	_fog_tex.update(_fog_image)
+        """Marks a tile as explored so its walls and contents remain visible."""
+        _discovered[tile] = true
 
 
 func _draw() -> void:
-	if _level_size == Vector2i.ZERO:
-		return
-	var rect := Rect2(Vector2.ZERO, Vector2(_level_size) * map_scale)
-	draw_texture_rect(_map_tex, rect, false)
-	draw_texture_rect(_fog_tex, rect, false)
+        if _level_size == Vector2i.ZERO:
+                return
 
-	if _player:
-		var p := (
-			Vector2(_player.global_position.x / _tile_size, _player.global_position.z / _tile_size)
-			* map_scale
-		)
-		draw_circle(p + Vector2(map_scale * 0.5, map_scale * 0.5), map_scale * 0.3, player_color)
-	if _level:
-		var enemies = _level.get_tree().get_nodes_in_group("enemy")
-		for e in enemies:
-			if not (e is Node3D):
-				continue
-			if (
-				_player
-				and (
-					(e as Node3D).global_position.distance_to(_player.global_position)
-					> enemy_reveal_distance
-				)
-			):
-				continue
-			var etile := Vector2i(
-				int(floor((e as Node3D).global_position.x / _tile_size)),
-				int(floor((e as Node3D).global_position.z / _tile_size))
-			)
-			if not _discovered.has(etile):
-				continue
-			var color := enemy_color
-			if "tier" in e and e.tier == e.Tier.BOSS:
-				color = boss_color
-			var pos := Vector2(etile) * map_scale + Vector2(map_scale * 0.5, map_scale * 0.5)
-			draw_circle(pos, map_scale * 0.3, color)
+        # Draw discovered wall segments.
+        var thickness := max(1.0, map_scale * 0.1)
+        for tile in _discovered.keys():
+                var base := Vector2(tile) * map_scale
+                var neighbors := [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
+                for dir in neighbors:
+                        var ntile := tile + dir
+                        var out_of_bounds := ntile.x < 0 or ntile.y < 0 or ntile.x >= _level_size.x or ntile.y >= _level_size.y
+                        if out_of_bounds or not _walkable.has(ntile):
+                                match dir:
+                                        Vector2i.UP:
+                                                draw_line(base, base + Vector2(map_scale, 0), wall_color, thickness)
+                                        Vector2i.DOWN:
+                                                draw_line(
+                                                        base + Vector2(0, map_scale),
+                                                        base + Vector2(map_scale, map_scale),
+                                                        wall_color,
+                                                        thickness
+                                                )
+                                        Vector2i.LEFT:
+                                                draw_line(base, base + Vector2(0, map_scale), wall_color, thickness)
+                                        Vector2i.RIGHT:
+                                                draw_line(
+                                                        base + Vector2(map_scale, 0),
+                                                        base + Vector2(map_scale, map_scale),
+                                                        wall_color,
+                                                        thickness
+                                                )
+
+        # Draw the player icon.
+        if _player:
+                var p := (
+                        Vector2(_player.global_position.x / _tile_size, _player.global_position.z / _tile_size)
+                        * map_scale
+                )
+                draw_circle(p + Vector2(map_scale * 0.5, map_scale * 0.5), map_scale * 0.3, player_color)
+
+        # Draw visible enemies and bosses.
+        if _level:
+                var enemies = _level.get_tree().get_nodes_in_group("enemy")
+                for e in enemies:
+                        if not (e is Node3D):
+                                continue
+                        if (
+                                _player
+                                and (
+                                        (e as Node3D).global_position.distance_to(_player.global_position)
+                                        > enemy_reveal_distance
+                                )
+                        ):
+                                continue
+                        var etile := Vector2i(
+                                int(floor((e as Node3D).global_position.x / _tile_size)),
+                                int(floor((e as Node3D).global_position.z / _tile_size))
+                        )
+                        if not _discovered.has(etile):
+                                continue
+                        var color := enemy_color
+                        if "tier" in e and e.tier == e.Tier.BOSS:
+                                color = boss_color
+                        var pos := Vector2(etile) * map_scale + Vector2(map_scale * 0.5, map_scale * 0.5)
+                        draw_circle(pos, map_scale * 0.3, color)


### PR DESCRIPTION
## Summary
- Render minimap walls as blue lines over a transparent background
- Add configurable fog-of-war reveal radius and wall color
- Document updated minimap behaviour and options

## Testing
- `apt-get install -y godot4` *(failed: Unable to locate package godot4)*
- `godot3-server --headless --check-only project.godot` *(failed: config_version 5 is from a more recent and incompatible version)*

------
https://chatgpt.com/codex/tasks/task_e_68c25e15c140832d9d2e4457447aaa45