### PR TITLE
Refine skill casting helpers for animation-driven combat

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ skills can optionally ignore collisions, stop on impact, apply damage in a
 radius while travelling and trigger particle effects when cast, while moving or
 upon arrival.
 
+### Active skill helpers
+Godot's resource-based skill system now exposes a few utilities that make it
+easier to author new abilities without duplicating boilerplate:
+
+- `Skill.get_tags()` returns a lowercase copy of the skill's tags so existing
+  resources like `"Spell"` or `"Projectile"` continue to work with the
+  animation-driven casting logic in `player.gd`.
+- `_prepare_buff_instance()` duplicates buffs before they are applied and, if
+  the buff deals damage over time, computes the correct `damage_per_second`
+  using the caster's offensive stats. This keeps shared resources immutable and
+  ensures aura toggles can remove the exact buff instance that was applied.
+- `_get_ground_target_position()` mirrors the player's `_get_click_position`
+  helper so radial skills such as area buffs and ground explosions can target a
+  point under the cursor even when triggered by AI-controlled enemies.
+- Helper methods like `_apply_damage_bundle()` and `get_body_mid_y()` centralise
+  common behaviour for spawning hit effects and applying damage so projectiles,
+  melee swings and area blasts all benefit from the same targeting rules.
+
+Additionally, `AuraSkill` now interprets `mana_reserve_percent` values greater
+than 1.0 as whole percentages (so an editor value of `25` reserves 25% of the
+caster's mana) and refunds the exact amount when the aura is deactivated.
+
 ## Player Animations
 The `player.gd` script now drives an `AnimationTree` for directional movement and attack animations.
 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -362,7 +362,7 @@ func _process_attack(delta: float) -> void:
 		if Input.is_action_pressed("attack") and _attack_timer <= 0.0 and main_skill and _attacking_timer <= 0.0:
 				if mana >= main_skill.mana_cost:
 						_anim_state.travel("move") #reset anim state
-						var speed = get_attack_speed(main_skill.tags)
+var speed = get_attack_speed(main_skill.get_tags())
 						print("Attack speed is ", speed)
 						_attack_timer = main_skill.cooldown / max(speed, 0.001)
 						_attacking_timer = main_skill.duration / max(speed, 0.001)

--- a/scripts/skills/area_buff_skill.gd
+++ b/scripts/skills/area_buff_skill.gd
@@ -4,29 +4,26 @@ class_name AreaBuffSkill
 @export var radius: float = 3.0
 @export var buff: Buff
 
-func perform(user):
-    if user == null or buff == null:
-        return
-    var camera = user.get_viewport().get_camera_3d()
-    if camera == null:
-        return
-    var mouse_pos = user.get_viewport().get_mouse_position()
-    var ray_origin = camera.project_ray_origin(mouse_pos)
-    var ray_dir = camera.project_ray_normal(mouse_pos)
-    var plane_y = user.global_transform.origin.y
-    if abs(ray_dir.y) <= 0.0001:
-        return
-    var distance = (plane_y - ray_origin.y) / ray_dir.y
-    var target = ray_origin + ray_dir * distance
-    var mult = user.stats.get_aoe_multiplier()
-    var shape = SphereShape3D.new()
-    shape.radius = radius * mult
-    var params = PhysicsShapeQueryParameters3D.new()
-    params.shape = shape
-    params.transform = Transform3D(Basis(), target)
-    params.collide_with_bodies = true
-    var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
-    for result in bodies:
-        var body = result.get("collider")
-        if body and body.has_method("add_buff"):
-            body.add_buff(buff)
+func perform(user) -> void:
+	if user == null or buff == null or not (user is Node3D):
+		return
+	var actor: Node3D = user
+	var target := _get_ground_target_position(user)
+	var mult := 1.0
+	if "stats" in user and user.stats:
+		mult = user.stats.get_aoe_multiplier()
+	var shape := SphereShape3D.new()
+	shape.radius = radius * mult
+	var params := PhysicsShapeQueryParameters3D.new()
+	params.shape = shape
+	params.transform = Transform3D(Basis(), target)
+	params.collide_with_bodies = true
+	var world := actor.get_world_3d()
+	if world == null:
+		return
+	var results := world.direct_space_state.intersect_shape(params, 128)
+	var buff_template := _prepare_buff_instance(buff, user)
+	for result in results:
+		var body := result.get("collider")
+		if body and body.has_method("add_buff") and buff_template:
+			body.add_buff(buff_template.duplicate(true))

--- a/scripts/skills/aura_skill.gd
+++ b/scripts/skills/aura_skill.gd
@@ -7,39 +7,46 @@ class_name AuraSkill
 
 var _active: Dictionary = {}
 
-func perform(user):
-	if user == null:
-		return
-	if _active.has(user):
-		_deactivate(user)
-	else:
-		var reserve = 0.0
-		if "max_mana" in user:
-			reserve = user.max_mana * mana_reserve_percent
-			if user.mana < reserve:
-				return
-			user.mana -= reserve
-			if "reserved_mana" in user:
-				user.reserved_mana += reserve
-		if buff and user.has_method("add_buff"):
-			user.add_buff(buff)
-		var effect
-		if aura_effect:
-			effect = aura_effect.instantiate()
-			user.add_child(effect)
-		_active[user] = {"reserve": reserve, "effect": effect}
+func perform(user) -> void:
+if user == null:
+return
+if _active.has(user):
+_deactivate(user)
+return
+var reserve_percent := mana_reserve_percent
+if reserve_percent > 1.0:
+reserve_percent *= 0.01
+var reserve := 0.0
+if "max_mana" in user:
+reserve = user.max_mana * reserve_percent
+if user.mana < reserve:
+return
+user.mana -= reserve
+if "reserved_mana" in user:
+user.reserved_mana += reserve
+var applied_buff := null
+if buff and user.has_method("add_buff"):
+applied_buff = _prepare_buff_instance(buff, user, false)
+if applied_buff:
+user.add_buff(applied_buff)
+var effect
+if aura_effect:
+effect = aura_effect.instantiate()
+user.add_child(effect)
+_active[user] = {"reserve": reserve, "effect": effect, "buff": applied_buff}
 
-func _deactivate(user):
-	var data = _active.get(user, null)
-	if data == null:
-		return
-	if buff and user.has_method("remove_buff"):
-		user.remove_buff(buff)
-	if data.effect and is_instance_valid(data.effect):
-		data.effect.queue_free()
-	if "mana" in user:
-		user.mana += data.reserve
-		if "reserved_mana" in user:
-			user.reserved_mana -= data.reserve
-			user.mana = min(user.mana, user.max_mana - user.reserved_mana)
-	_active.erase(user)
+func _deactivate(user) -> void:
+var data = _active.get(user, null)
+if data == null:
+return
+var applied_buff = data.get("buff", buff)
+if applied_buff and user.has_method("remove_buff"):
+user.remove_buff(applied_buff)
+if data.effect and is_instance_valid(data.effect):
+data.effect.queue_free()
+if "mana" in user:
+user.mana += data.reserve
+if "reserved_mana" in user:
+user.reserved_mana -= data.reserve
+user.mana = min(user.mana, user.max_mana - user.reserved_mana)
+_active.erase(user)

--- a/scripts/skills/blast_skill.gd
+++ b/scripts/skills/blast_skill.gd
@@ -1,66 +1,46 @@
 extends Skill
 class_name BlastSkill
 
-@export var radius: float = 3.0 # Base explosion radius
-@export var on_hit_effect: PackedScene # Effect spawned on struck bodies
-@export var explosion_effect: PackedScene # Effect placed at blast center
-@export var on_hit_buff: Buff # Buff or debuff applied to bodies hit
+@export var radius: float = 3.0 ## Base explosion radius in metres.
+@export var on_hit_effect: PackedScene ## Effect spawned on struck bodies.
+@export var explosion_effect: PackedScene ## Effect placed at blast centre.
+@export var on_hit_buff: Buff ## Buff or debuff applied to bodies hit.
 
-func perform(user):
-	if user == null:
-			return
-	var camera = user.get_viewport().get_camera_3d()
-	if camera == null:
-			return
-	var mouse_pos = user.get_viewport().get_mouse_position()
-	var ray_origin = camera.project_ray_origin(mouse_pos)
-	var ray_dir = camera.project_ray_normal(mouse_pos)
-	var plane_y = user.global_transform.origin.y
-	if abs(ray_dir.y) <= 0.0001:
+## Detonates an area at the cursor position, damaging everything inside the
+## radius. Works for both the player and AI controlled casters.
+func perform(user) -> void:
+	if user == null or not (user is Node3D):
 		return
-	var distance = (plane_y - ray_origin.y) / ray_dir.y
-	var target = ray_origin + ray_dir * distance
-   # Snapshot values before the user might die
-	var base_dict = _build_base_damage_dict(user)
-	var dmg_map = user.stats.compute_damage(base_dict, tags)
-	var buff_snapshot
-	if on_hit_buff:
-		buff_snapshot = on_hit_buff.duplicate(true)
-		if buff_snapshot is DamageOverTimeBuff:
-			var dot_dict = {buff_snapshot.damage_type: Vector2(buff_snapshot.base_damage_low, buff_snapshot.base_damage_high)}
-			var dot_map = user.stats.compute_damage(dot_dict, tags)
-			buff_snapshot.damage_per_second = dot_map[buff_snapshot.damage_type]
-	var is_player = user.is_in_group("player")
-	var mult = user.stats.get_aoe_multiplier()
-	var world = user.get_world_3d()
-	var parent = user.get_parent()
-	_explode(target, parent, world, dmg_map, buff_snapshot, mult, is_player)
+	var actor: Node3D = user
+	var target := _get_ground_target_position(user)
+	var dmg_map: Dictionary = {}
+	if "stats" in user and user.stats:
+		var base_dict := _build_base_damage_dict(user)
+		dmg_map = user.stats.compute_damage(base_dict, get_tags())
+	var buff_template := _prepare_buff_instance(on_hit_buff, user)
+	var is_player := user.is_in_group("player")
+	var mult := 1.0
+	if "stats" in user and user.stats:
+		mult = user.stats.get_aoe_multiplier()
+	_explode(actor, target, dmg_map, buff_template, mult, is_player)
 
-func _explode(origin: Vector3, parent, world, dmg_map, buff_snapshot, mult, is_player):
-	var shape = SphereShape3D.new()
-	shape.radius = radius * mult
-	var params = PhysicsShapeQueryParameters3D.new()
+func _explode(actor: Node3D, origin: Vector3, dmg_map: Dictionary, buff_template: Buff, mult: float, is_player: bool) -> void:
+	var world := actor.get_world_3d()
+	if world == null:
+		return
+	var shape := SphereShape3D.new()
+	shape.radius = max(radius * mult, 0.0)
+	var params := PhysicsShapeQueryParameters3D.new()
 	params.shape = shape
 	params.transform = Transform3D(Basis(), origin)
 	params.collide_with_bodies = true
-	var bodies = world.direct_space_state.intersect_shape(params)
-	for result in bodies:
-			var body = result.get("collider")
-			if body and body.has_method("take_damage"):
-					if (is_player and body.is_in_group("enemy")) or (not is_player and body.is_in_group("player")):
-							for dt in dmg_map.keys():
-									var dmg = dmg_map[dt]
-									if dmg > 0:
-											body.take_damage(dmg, dt)
-							if buff_snapshot and body.has_method("add_buff"):
-								body.add_buff(buff_snapshot.duplicate(true))
-							if on_hit_effect:
-									var eff = on_hit_effect.instantiate()
-									eff.global_transform = body.global_transform
-									body.get_tree().current_scene.add_child(eff)
-
-	if explosion_effect:
-			var e = explosion_effect.instantiate()
-			e.global_transform.origin = origin
-			e.scale = Vector3.ONE * radius * mult
-			parent.add_child(e)
+	var results := world.direct_space_state.intersect_shape(params, 1024)
+	for result in results:
+		var body := result.get("collider")
+		if body:
+			_apply_damage_bundle(body, dmg_map, buff_template, is_player, on_hit_effect)
+	if explosion_effect and actor.get_parent():
+		var e := explosion_effect.instantiate()
+		e.global_transform.origin = origin
+		e.scale = Vector3.ONE * max(radius * mult, 0.01)
+		actor.get_parent().add_child(e)

--- a/scripts/skills/combo_skill.gd
+++ b/scripts/skills/combo_skill.gd
@@ -3,7 +3,9 @@ class_name ComboSkill
 
 @export var skills: Array[Skill] = []
 
-func perform(user):
-	for s in skills:
-		if s:
-			s.perform(user)
+func perform(user) -> void:
+if user == null:
+return
+for s in skills:
+if s:
+s.perform(user)

--- a/scripts/skills/melee_skill.gd
+++ b/scripts/skills/melee_skill.gd
@@ -1,72 +1,59 @@
 extends Skill
 class_name MeleeSkill
 
-@export var range: float = 2.0 # Radius of the swing
+@export var range: float = 2.0 ## Radius of the swing in metres.
 @export var angle: float = 45.0
-@export var on_hit_effect: PackedScene # Effect spawned on struck bodies
-@export var on_hit_buff: Buff # Buff or debuff applied to bodies hit
+@export var on_hit_effect: PackedScene ## Effect spawned on struck bodies.
+@export var on_hit_buff: Buff ## Buff or debuff applied to bodies hit.
 
-func perform(user):
-	if user == null:
-			return
-	var direction: Vector3
-	if user.has_method("_get_click_direction"):
-			direction = user._get_click_direction()
-	else:
-		direction = -user.global_transform.basis.z
-		user.look_at(user.global_transform.origin + direction, Vector3.UP)
-	var attack_area = Area3D.new()
-	var shape = CylinderShape3D.new()
-	shape.height = 1.0
-	shape.radius = range
-	var collider = CollisionShape3D.new()
-	collider.shape = shape
-	attack_area.add_child(collider)
-	attack_area.transform.origin = user.global_transform.origin + direction * range
-	user.get_parent().add_child(attack_area)
-	var mesh = MeshInstance3D.new()
-	mesh.mesh = CylinderMesh.new()
-	mesh.mesh.top_radius = range
-	mesh.mesh.bottom_radius = range
-	mesh.mesh.height = 1.0
-	mesh.material_override = StandardMaterial3D.new()
-	mesh.material_override.albedo_color = Color(1, 0, 0, 0.5)
-	mesh.visible = true
-	#attack_area.add_child(mesh)
-	var timer = Timer.new()
-	timer.wait_time = 0.1
-	timer.one_shot = true
-	timer.autostart = true
-	timer.connect("timeout", Callable(attack_area, "queue_free"))
-	attack_area.add_child(timer)
-	var params = PhysicsShapeQueryParameters3D.new()
-	params.shape = shape
-	params.transform = attack_area.global_transform
-	params.collide_with_bodies = true
-	var bodies = user.get_world_3d().direct_space_state.intersect_shape(params)
-	   # Snapshot damage and team info so hits remain valid if the user dies mid‑attack
-	var base_dict = _build_base_damage_dict(user)
-	var dmg_map = user.stats.compute_damage(base_dict, tags)
-	var buff_snapshot
-	if on_hit_buff:
-			buff_snapshot = on_hit_buff.duplicate(true)
-			if buff_snapshot is DamageOverTimeBuff:
-					var dot_dict = {buff_snapshot.damage_type: Vector2(buff_snapshot.base_damage_low, buff_snapshot.base_damage_high)}
-					var dot_map = user.stats.compute_damage(dot_dict, tags)
-					buff_snapshot.damage_per_second = dot_map[buff_snapshot.damage_type]
-	var is_player = user.is_in_group("player")
-	for result in bodies:
-			var body = result.get("collider")
-			if body and body.has_method("take_damage"):
-					if (is_player and body.is_in_group("enemy")) or (not is_player and body.is_in_group("player")):
-							for dt in dmg_map.keys():
-									var dmg = dmg_map[dt]
-									if dmg > 0:
-											body.take_damage(dmg, dt)
-							if buff_snapshot and body.has_method("add_buff"):
-									body.add_buff(buff_snapshot.duplicate(true))
-							if on_hit_effect:
-									var eff = on_hit_effect.instantiate()
-									eff.global_transform = body.global_transform
-									eff.position.y += 2
-									body.get_tree().current_scene.add_child(eff)
+## Performs a simple radial sweep in front of the user and applies damage to
+## valid targets. The implementation relies on the shared helpers in `Skill`
+## so it integrates with the animation-driven combat flow in `Player.gd`.
+func perform(user) -> void:
+if user == null or not (user is Node3D):
+return
+var actor: Node3D = user
+var direction := Vector3.ZERO
+if user.has_method("_get_click_direction"):
+direction = user._get_click_direction()
+else:
+direction = -actor.global_transform.basis.z
+actor.look_at(actor.global_transform.origin + direction, Vector3.UP)
+if direction == Vector3.ZERO:
+return
+var parent := actor.get_parent()
+if parent == null:
+return
+var attack_area := Area3D.new()
+var shape := CylinderShape3D.new()
+shape.height = 1.0
+shape.radius = range
+var collider := CollisionShape3D.new()
+collider.shape = shape
+attack_area.add_child(collider)
+attack_area.transform.origin = actor.global_transform.origin + direction * range
+parent.add_child(attack_area)
+var timer := Timer.new()
+timer.wait_time = 0.1
+timer.one_shot = true
+timer.autostart = true
+timer.timeout.connect(Callable(attack_area, "queue_free"))
+attack_area.add_child(timer)
+var params := PhysicsShapeQueryParameters3D.new()
+params.shape = shape
+params.transform = attack_area.global_transform
+params.collide_with_bodies = true
+var space := actor.get_world_3d()
+if space == null:
+return
+var results := space.direct_space_state.intersect_shape(params, 32)
+var dmg_map: Dictionary = {}
+if "stats" in user and user.stats:
+var base_dict := _build_base_damage_dict(user)
+dmg_map = user.stats.compute_damage(base_dict, get_tags())
+var buff_template := _prepare_buff_instance(on_hit_buff, user)
+var is_player := user.is_in_group("player")
+for result in results:
+var body := result.get("collider")
+if body:
+_apply_damage_bundle(body, dmg_map, buff_template, is_player, on_hit_effect)

--- a/scripts/skills/movement_skill.gd
+++ b/scripts/skills/movement_skill.gd
@@ -24,24 +24,21 @@ extends Skill
 @export var active_effect: PackedScene
 
 
-func perform(user):
-	if user == null:
+func perform(user) -> void:
+	if user == null or not (user is Node3D):
 		return
-	var target: Vector3
-	if user.has_method("_get_click_position"):
-		target = user._get_click_position()
-	else:
-		return
-	var origin: Vector3 = user.global_transform.origin
+	var actor: Node3D = user
+	var target := _get_ground_target_position(user)
+	var origin: Vector3 = actor.global_transform.origin
 	var direction: Vector3 = target - origin
 	var distance: float = direction.length()
 	if distance <= 0.01:
 		return
 	direction = direction.normalized()
 	var dmg_map: Dictionary = {}
-	if damage_radius > 0.0 and user.stats:
+	if damage_radius > 0.0 and "stats" in user and user.stats:
 		var base_dict = _build_base_damage_dict(user)
-		dmg_map = user.stats.compute_damage(base_dict, tags)
+		dmg_map = user.stats.compute_damage(base_dict, get_tags())
 	# Delegate the actual motion to the user so it can integrate with
 	# existing movement code.
 	if user.has_method("start_movement_skill"):

--- a/scripts/skills/projectile_skill.gd
+++ b/scripts/skills/projectile_skill.gd
@@ -9,201 +9,121 @@ class_name ProjectileSkill
 @export var explosion_effect: PackedScene # Effect placed at explosion center
 @export var on_hit_buff: Buff # Buff or debuff applied to bodies hit
 
-func perform(user):
-	if user == null:
-			return
-	var direction: Vector3
+## Launches a projectile toward the cursor.  Damage, on-hit buffs and optional
+## explosions are resolved using metadata stored on the spawned projectile so
+## the behaviour survives even if the caster is removed mid-flight.
+func perform(user) -> void:
+	if user == null or not (user is Node3D):
+		return
+	var actor: Node3D = user
+	var direction := Vector3.ZERO
 	if user.has_method("_get_click_direction"):
-			direction = user._get_click_direction()
+		direction = user._get_click_direction()
 	else:
-		direction = -user.global_transform.basis.z
-	user.look_at(user.global_transform.origin + direction, Vector3.UP)
-	var projectile = _create_projectile()
-	   # Snapshot all values needed so the projectile can resolve damage even if the user dies
-	var base_dict = _build_base_damage_dict(user)
-	var dmg_map = user.stats.compute_damage(base_dict, tags)
-	var buff_snapshot
-	if on_hit_buff:
-			buff_snapshot = on_hit_buff.duplicate(true)
-			if buff_snapshot is DamageOverTimeBuff:
-					var dot_dict = {buff_snapshot.damage_type: Vector2(buff_snapshot.base_damage_low, buff_snapshot.base_damage_high)}
-					var dot_map = user.stats.compute_damage(dot_dict, tags)
-					buff_snapshot.damage_per_second = dot_map[buff_snapshot.damage_type]
-	projectile.set_meta("dmg_map", dmg_map)
-	projectile.set_meta("buff_snapshot", buff_snapshot)
-	projectile.set_meta("aoe_mult", user.stats.get_aoe_multiplier())
-	projectile.set_meta("is_player", user.is_in_group("player"))
+		direction = -actor.global_transform.basis.z
+	if direction == Vector3.ZERO:
+		return
+	actor.look_at(actor.global_transform.origin + direction, Vector3.UP)
+	var projectile := _create_projectile()
+	if projectile == null:
+		return
+	var dmg_map: Dictionary = {}
+	if "stats" in user and user.stats:
+		var base_dict := _build_base_damage_dict(user)
+		dmg_map = user.stats.compute_damage(base_dict, get_tags())
+	var buff_template := _prepare_buff_instance(on_hit_buff, user)
+	var aoe_mult := 1.0
+	if "stats" in user and user.stats:
+		aoe_mult = user.stats.get_aoe_multiplier()
+# Cache all data needed to resolve the hit so we can apply damage even if the
+# caster dies while the projectile is active.
+projectile.set_meta("dmg_map", dmg_map)
+projectile.set_meta("buff_template", buff_template)
+projectile.set_meta("aoe_mult", aoe_mult)
+projectile.set_meta("is_player", user.is_in_group("player"))
 	projectile.body_entered.connect(_on_projectile_body_entered.bind(projectile))
-	user.get_parent().add_child(projectile)
-	projectile.global_transform.origin = user.global_transform.origin + direction
+	var parent := actor.get_parent()
+	if parent == null:
+		return
+	parent.add_child(projectile)
+	projectile.global_transform.origin = actor.global_transform.origin + direction
 	projectile.position.y += 2
-	var look_target = projectile.global_transform.origin + direction
+	var look_target := projectile.global_transform.origin + direction
 	projectile.look_at(look_target, Vector3.UP)
-	var travel_time = range / speed
-	var tween = projectile.create_tween()
-	tween.tween_property(projectile, "global_transform:origin", user.global_transform.origin + direction * range, travel_time)
-	tween.connect("finished", Callable(self, "_on_projectile_finished").bind(projectile))
+	var travel_time := range / max(speed, 0.001)
+	var tween := projectile.create_tween()
+	tween.tween_property(projectile, "global_transform:origin", actor.global_transform.origin + direction * range, travel_time)
+	tween.finished.connect(Callable(self, "_on_projectile_finished").bind(projectile))
 
 func _create_projectile():
 	if projectile_scene:
 		return projectile_scene.instantiate()
-	var p = Area3D.new()
-	var shape = SphereShape3D.new()
+	var p := Area3D.new()
+	var shape := SphereShape3D.new()
 	shape.radius = 0.2
-	var collider = CollisionShape3D.new()
+	var collider := CollisionShape3D.new()
 	collider.shape = shape
 	p.add_child(collider)
-	var mesh = MeshInstance3D.new()
+	var mesh := MeshInstance3D.new()
 	mesh.mesh = SphereMesh.new()
 	p.add_child(mesh)
 	return p
 
 func _on_projectile_body_entered(body, projectile):
-	var is_player = projectile.get_meta("is_player")
-	if body and body.has_method("take_damage"):
-			
-			if (is_player and body.is_in_group("enemy")) or (not is_player and body.is_in_group("player")):
-					var dmg_map = projectile.get_meta("dmg_map")
-					for dt in dmg_map.keys():
-							var dmg = dmg_map[dt]
-							if dmg > 0:
-									body.take_damage(dmg, dt)
-					var buff_snapshot = projectile.get_meta("buff_snapshot")
-					if buff_snapshot and body.has_method("add_buff"):
-							body.add_buff(buff_snapshot.duplicate(true))
-					if on_hit_effect:
-						var eff = on_hit_effect.instantiate()
-						var p = body.global_transform.origin
-						p.y = mid_y_of_body(body)
-						eff.global_transform.origin = p
-						body.get_tree().current_scene.add_child(eff)
-	if(is_player and body.is_in_group("player")):
+	if not is_instance_valid(projectile):
 		return
+	var is_player := projectile.has_meta("is_player") and projectile.get_meta("is_player")
+	var dmg_map: Dictionary = {}
+	if projectile.has_meta("dmg_map"):
+		dmg_map = projectile.get_meta("dmg_map")
+	var buff_template := null
+	if projectile.has_meta("buff_template"):
+		buff_template = projectile.get_meta("buff_template")
+	_apply_damage_bundle(body, dmg_map, buff_template, is_player, on_hit_effect)
 	_explode(projectile)
 	projectile.queue_free()
 
 func _on_projectile_finished(projectile):
 	_explode(projectile)
-	projectile.queue_free()
+	if is_instance_valid(projectile):
+		projectile.queue_free()
 
 func _explode(projectile):
-	#print("BOOM!")
-	var origin = projectile.global_transform.origin
-	if explosion_radius <= 0.0:
-			if explosion_effect:
-					var eff = explosion_effect.instantiate()
-					eff.global_transform.origin = origin
-					projectile.get_parent().add_child(eff)
-			return
-	var mult = projectile.get_meta("aoe_mult")
-	var shape = SphereShape3D.new()
+if not is_instance_valid(projectile):
+return
+var origin := projectile.global_transform.origin
+if explosion_radius <= 0.0:
+		if explosion_effect and projectile.get_parent():
+			var eff := explosion_effect.instantiate()
+			eff.global_transform.origin = origin
+			projectile.get_parent().add_child(eff)
+		return
+	var mult := 1.0
+	if projectile.has_meta("aoe_mult"):
+		mult = projectile.get_meta("aoe_mult")
+	var shape := SphereShape3D.new()
 	shape.radius = explosion_radius * mult
-	var params = PhysicsShapeQueryParameters3D.new()
+	var params := PhysicsShapeQueryParameters3D.new()
 	params.shape = shape
 	params.transform = Transform3D(Basis(), origin)
 	params.collide_with_bodies = true
-	var bodies = projectile.get_world_3d().direct_space_state.intersect_shape(params, 1024)
-	var dmg_map = projectile.get_meta("dmg_map")
-	var buff_snapshot = projectile.get_meta("buff_snapshot")
-	var is_player = projectile.get_meta("is_player")
-	for result in bodies:
-			var body = result.get("collider")
-			if body and body.has_method("take_damage"):
-					if (is_player and body.is_in_group("enemy")) or (not is_player and body.is_in_group("player")):
-							print(dmg_map)
-							for dt in dmg_map.keys():
-									var dmg = dmg_map[dt]
-									if dmg > 0:
-											body.take_damage(dmg, dt)
-							if buff_snapshot and body.has_method("add_buff"):
-									body.add_buff(buff_snapshot.duplicate(true))
-							if on_hit_effect:
-									var eff = on_hit_effect.instantiate()
-									var p = body.global_transform.origin
-									p.y = mid_y_of_body(body)
-									body.get_tree().current_scene.add_child(eff)
-									eff.global_transform.origin = p
-									
-	if explosion_effect:
-			var e = explosion_effect.instantiate()
-			e.global_transform.origin = origin
-			e.scale = Vector3.ONE * explosion_radius * mult
-			projectile.get_parent().add_child(e)
-			
-# --- Bounds helpers (Godot 4) ---
-
-func _world_y_bounds(root: Node3D) -> Vector2:
-	var min_y := INF
-	var max_y := -INF
-	var stack: Array[Node3D] = [root]
-
-	while stack.size() > 0:
-		var n: Node3D = stack.pop_back()
-
-		# Meshes (most accurate visually)
-		if n is MeshInstance3D and n.mesh:
-			var aabb: AABB = n.mesh.get_aabb() # local space
-			# Transform AABB corners to world space and track y-extents
-			var xform := n.global_transform
-			var p := aabb.position
-			var s := aabb.size
-			var corners := [
-				p,
-				p + Vector3(s.x, 0, 0),
-				p + Vector3(0, s.y, 0),
-				p + Vector3(0, 0, s.z),
-				p + Vector3(s.x, s.y, 0),
-				p + Vector3(s.x, 0, s.z),
-				p + Vector3(0, s.y, s.z),
-				p + s
-			]
-			for c in corners:
-				var wc = xform * c
-				min_y = min(min_y, wc.y)
-				max_y = max(max_y, wc.y)
-
-		# Collision shapes (approximate fallback)
-		elif n is CollisionShape3D and n.shape:
-			var gt := n.global_transform
-			var sc := gt.basis.get_scale().abs()
-			var oy := gt.origin.y
-
-			match n.shape:
-				BoxShape3D:
-					var half = (n.shape.size * sc) * 0.5
-					min_y = min(min_y, oy - half.y)
-					max_y = max(max_y, oy + half.y)
-
-				SphereShape3D:
-					var r = n.shape.radius * max(sc.x, max(sc.y, sc.z))
-					min_y = min(min_y, oy - r)
-					max_y = max(max_y, oy + r)
-
-				CapsuleShape3D:
-					# Capsule aligned to Y in Godot
-					var r = n.shape.radius * max(sc.x, sc.z)
-					var h_cyl = n.shape.height * sc.y
-					var h_total = h_cyl + 2.0 * r
-					min_y = min(min_y, oy - h_total * 0.5)
-					max_y = max(max_y, oy + h_total * 0.5)
-
-				CylinderShape3D:
-					var r = n.shape.radius * max(sc.x, sc.z)
-					var h = n.shape.height * sc.y
-					min_y = min(min_y, oy - h * 0.5)
-					max_y = max(max_y, oy + h * 0.5)
-
-		# Traverse
-		for c in n.get_children():
-			if c is Node3D:
-				stack.push_back(c)
-
-	# If nothing was found, default to root's Y
-	if min_y == INF:
-		var y := root.global_transform.origin.y
-		return Vector2(y, y)
-	return Vector2(min_y, max_y)
-
-func mid_y_of_body(root: Node3D) -> float:
-	var b := _world_y_bounds(root)
-	return 0.5 * (b.x + b.y)
+	var world := projectile.get_world_3d()
+	if world == null:
+		return
+var results := world.direct_space_state.intersect_shape(params, 1024)
+var dmg_map: Dictionary = {}
+	if projectile.has_meta("dmg_map"):
+		dmg_map = projectile.get_meta("dmg_map")
+	var buff_template := null
+	if projectile.has_meta("buff_template"):
+		buff_template = projectile.get_meta("buff_template")
+	var is_player := projectile.has_meta("is_player") and projectile.get_meta("is_player")
+	for result in results:
+		var body := result.get("collider")
+		if body:
+			_apply_damage_bundle(body, dmg_map, buff_template, is_player, on_hit_effect)
+if explosion_effect and projectile.get_parent():
+var e := explosion_effect.instantiate()
+e.global_transform.origin = origin
+e.scale = Vector3.ONE * explosion_radius * mult
+projectile.get_parent().add_child(e)

--- a/scripts/skills/self_buff_skill.gd
+++ b/scripts/skills/self_buff_skill.gd
@@ -3,8 +3,10 @@ class_name SelfBuffSkill
 
 @export var buff: Buff
 
-func perform(user):
-    if user == null or buff == null:
-        return
-    if user.has_method("add_buff"):
-        user.add_buff(buff)
+func perform(user) -> void:
+	if user == null or buff == null:
+		return
+	if user.has_method("add_buff"):
+		var inst := _prepare_buff_instance(buff, user)
+		if inst:
+			user.add_buff(inst)

--- a/scripts/skills/skill.gd
+++ b/scripts/skills/skill.gd
@@ -1,6 +1,15 @@
 class_name Skill
 extends Resource
 
+## Base resource for all active skills.
+##
+## Each subclass implements `perform(user)` which executes the skill logic
+## when the owning actor (player, enemy, etc.) triggers it.  The base class
+## provides helpers for common bookkeeping such as tag normalisation, damage
+## dictionary construction and creating buff instances.  The goal is to keep
+## individual skill scripts focused on their unique behaviour while the
+## reusable glue lives here.
+
 @export var name: String = ""
 @export_multiline var description: String = ""
 @export var icon: Texture2D
@@ -16,18 +25,180 @@ extends Resource
 @export var attack_time: float = 0.0 ## Seconds into the animation when the attack is applied.
 @export var cancel_time: float = 0.0 ## Seconds into the animation when the remainder can be cancelled.
 
-func perform(user):
-	pass
+func perform(user: Node) -> void:
+"""Execute the skill for the given user.  Subclasses override this."""
+pass
 
-# Helper to construct the damage dictionary passed to Stats.compute_damage.
-# By default this uses the skill's own base damage values but, if the user
-# (player or enemy) exposes a `get_base_damage_dict(tags)` method, those values
-# are merged in.  This lets enemies define innate damage ranges and allows
-# players to contribute weapon damage only when the skill's tags match the
-# weapon type.
+## Returns a lowercase copy of the configured tags.
+##
+## `Player.gd` and other gameplay systems expect tags to be lowercase when
+## checking for keywords such as `melee` or `spell`.  Many existing resources
+## store them with capitalisation ("Spell", "AoE"), so normalising them here
+## keeps older data working with the new casting flow.
+func get_tags() -> Array[String]:
+var result: Array[String] = []
+for tag in tags:
+if typeof(tag) == TYPE_STRING:
+var cleaned := String(tag).strip_edges().to_lower()
+if not cleaned.is_empty():
+result.append(cleaned)
+return result
+
+## Helper to construct the damage dictionary passed to `Stats.compute_damage`.
+##
+## By default this uses the skill's own base damage values but, if the user
+## (player or enemy) exposes a `get_base_damage_dict(tags)` method, those values
+## are merged in.  This lets enemies define innate damage ranges and allows
+## players to contribute weapon damage only when the skill's tags match the
+## weapon type.
 func _build_base_damage_dict(user) -> Dictionary:
-		var dict: Dictionary = {}
-		if user and user.has_method("get_base_damage_dict"):
-				dict = user.get_base_damage_dict(tags)
-		dict[damage_type] = Vector2(base_damage_low, base_damage_high)
-		return dict
+var dict: Dictionary = {}
+var normalized_tags := get_tags()
+if user and user.has_method("get_base_damage_dict"):
+dict = user.get_base_damage_dict(normalized_tags)
+dict[damage_type] = Vector2(base_damage_low, base_damage_high)
+return dict
+
+## Creates a buff instance tailored for the current cast.
+##
+## * If `duplicate` is `true` (the default), a deep copy of the supplied buff
+##   is created.  This prevents shared resources from having their internal
+##   state mutated by multiple entities.
+## * When the buff is a `DamageOverTimeBuff` the helper computes its final
+##   damage-per-second using the user's offensive stats so the effect scales
+##   with the caster just like direct damage.
+## * A non-duplicated DoT will still be copied to avoid modifying the shared
+##   resource in-place.
+func _prepare_buff_instance(buff: Buff, user, duplicate: bool = true) -> Buff:
+if buff == null:
+return null
+var instance: Buff = buff
+if duplicate or instance is DamageOverTimeBuff:
+instance = buff.duplicate(true)
+if instance is DamageOverTimeBuff and user and "stats" in user and user.stats:
+var dot: DamageOverTimeBuff = instance
+var dot_dict := {dot.damage_type: Vector2(dot.base_damage_low, dot.base_damage_high)}
+var tags_for_dot := get_tags()
+var damage_map := user.stats.compute_damage(dot_dict, tags_for_dot)
+dot.damage_per_second = damage_map.get(dot.damage_type, 0.0)
+return instance
+
+## Returns true if `body` should take damage from the current caster.
+func _is_valid_target(body: Node, is_player: bool) -> bool:
+if body == null or not body.has_method("take_damage"):
+return false
+if is_player:
+return body.is_in_group("enemy")
+return body.is_in_group("player")
+
+## Applies damage, buffs and optional hit effects to a target body.
+func _apply_damage_bundle(body: Node, dmg_map: Dictionary, buff_template: Buff, is_player: bool, effect: PackedScene = null) -> void:
+if not _is_valid_target(body, is_player):
+return
+for dt in dmg_map.keys():
+var dmg = dmg_map[dt]
+if dmg > 0.0:
+body.take_damage(dmg, dt)
+if buff_template and body.has_method("add_buff"):
+body.add_buff(buff_template.duplicate(true))
+if effect and body is Node3D and body.get_tree():
+var eff = effect.instantiate()
+var origin := (body as Node3D).global_transform.origin
+origin.y = get_body_mid_y(body)
+eff.global_transform.origin = origin
+body.get_tree().current_scene.add_child(eff)
+
+## Calculates the mid-point on the Y axis for a 3D body.
+##
+## Effects spawned on enemies should appear roughly centred vertically.  We
+## inspect meshes first for accuracy and fall back to collision shapes when a
+## render mesh is not present.  If nothing is available the body's origin is
+## used.
+func get_body_mid_y(root: Node3D) -> float:
+var bounds := _world_y_bounds(root)
+return 0.5 * (bounds.x + bounds.y)
+
+## Shared logic for `get_body_mid_y` – traverses the node hierarchy to find
+## vertical bounds in world space.
+func _world_y_bounds(root: Node3D) -> Vector2:
+var min_y := INF
+var max_y := -INF
+var stack: Array[Node3D] = [root]
+while stack.size() > 0:
+var n: Node3D = stack.pop_back()
+if n is MeshInstance3D and n.mesh:
+var aabb: AABB = n.mesh.get_aabb()
+var xform := n.global_transform
+var p := aabb.position
+var s := aabb.size
+var corners := [
+p,
+p + Vector3(s.x, 0, 0),
+p + Vector3(0, s.y, 0),
+p + Vector3(0, 0, s.z),
+p + Vector3(s.x, s.y, 0),
+p + Vector3(s.x, 0, s.z),
+p + Vector3(0, s.y, s.z),
+p + s
+]
+for c in corners:
+var wc := xform * c
+min_y = min(min_y, wc.y)
+max_y = max(max_y, wc.y)
+elif n is CollisionShape3D and n.shape:
+var gt := n.global_transform
+var sc := gt.basis.get_scale().abs()
+var oy := gt.origin.y
+match n.shape:
+BoxShape3D:
+var half = (n.shape.size * sc) * 0.5
+min_y = min(min_y, oy - half.y)
+max_y = max(max_y, oy + half.y)
+SphereShape3D:
+var r = n.shape.radius * max(sc.x, max(sc.y, sc.z))
+min_y = min(min_y, oy - r)
+max_y = max(max_y, oy + r)
+CapsuleShape3D:
+var r_caps = n.shape.radius * max(sc.x, sc.z)
+var h_cyl = n.shape.height * sc.y
+var h_total = h_cyl + 2.0 * r_caps
+min_y = min(min_y, oy - h_total * 0.5)
+max_y = max(max_y, oy + h_total * 0.5)
+CylinderShape3D:
+var r_cyl = n.shape.radius * max(sc.x, sc.z)
+var h = n.shape.height * sc.y
+min_y = min(min_y, oy - h * 0.5)
+max_y = max(max_y, oy + h * 0.5)
+for child in n.get_children():
+if child is Node3D:
+stack.append(child)
+if min_y == INF:
+var y := root.global_transform.origin.y
+return Vector2(y, y)
+return Vector2(min_y, max_y)
+
+## Casts a ray from the camera (or cursor helper) to find a ground point in
+## front of the user.  The returned position lives on the horizontal plane at
+## the actor's height, matching the behaviour of `_get_click_position` in
+## `Player.gd`.
+func _get_ground_target_position(user) -> Vector3:
+if user == null:
+return Vector3.ZERO
+if user.has_method("_get_click_position"):
+return user._get_click_position()
+var actor := user as Node3D
+if actor == null:
+return Vector3.ZERO
+var viewport := actor.get_viewport()
+if viewport:
+var cam := viewport.get_camera_3d()
+if cam:
+var mouse := viewport.get_mouse_position()
+var ray_origin := cam.project_ray_origin(mouse)
+var ray_dir := cam.project_ray_normal(mouse)
+if abs(ray_dir.y) > 0.0001:
+var plane_y := actor.global_transform.origin.y
+var distance := (plane_y - ray_origin.y) / ray_dir.y
+if distance >= 0.0:
+return ray_origin + ray_dir * distance
+return actor.global_transform.origin


### PR DESCRIPTION
## Summary
- add shared helpers to `Skill` for normalised tags, reusable damage logic and cursor-ground targeting to stabilise the casting workflow
- update the player to rely on the normalised tag list when calculating attack speed so weapon modifiers apply consistently
- refactor melee, projectile, blast, movement and buff skills to use the new helpers and document the workflow changes in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf0412704832d87fbcaef8cfdd204